### PR TITLE
Add CONTRIBUTING guide  stable vs alpha tags, bug report checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to AWeb3
+
+Thanks for your interest in contributing!
+
+## Where to start (stable vs. alpha)
+
+- **Stable / baseline source:** the `main` branch tracks the original AWeb 3.4 APL open source baseline.
+- **AWeb 3.6 alpha sources:** development snapshots are published as **tags** (e.g. `AWeb3.6aX`).
+  For testing the newest alpha, check out the newest 3.6 alpha tag from Releases/Tags.
+
+Links:
+- https://github.com/amigazen/AWeb3/releases
+- https://github.com/amigazen/AWeb3/tags
+
+Example:
+```sh
+git clone https://github.com/amigazen/AWeb3.git
+cd AWeb3
+git checkout AWeb3.6a6
+```
+
+## What we welcome
+
+- Bug reports with clear steps to reproduce
+- Testing (especially regressions between alpha tags)
+- Documentation and translations
+- Small, focused code changes (one fix per PR)
+
+## Bug reports (please include)
+
+- AWeb version (stable or alpha tag, e.g. AWeb3.6a6)
+- Amiga setup (CPU, RAM, OS version, TCP stack, AmiSSL version, graphics system)
+- Steps to reproduce
+- Expected vs. actual result
+- If possible: a minimal test case (URL or small HTML/MD file)
+
+## Pull requests
+
+- Keep changes small and focused.
+- Prefer one logical change per PR (easier to review and merge).
+- Describe the problem and how your change fixes it.
+


### PR DESCRIPTION
This adds a short CONTRIBUTING guide clarifying where stable sources live (`main`) vs. where AWeb 3.6 alpha snapshots are published (tags/releases), plus a small checklist for bug reports and PR scope.

Docs only; no code changes.

This came up while trying to contribute based on the website’s 3.6 alpha messaging; the repo landing page is otherwise easy to misread.