### PR TITLE
fetch: prevent buffer overflow in error/status formatting

### DIFF
--- a/Source/AWebAPL/fetch.c
+++ b/Source/AWebAPL/fetch.c
@@ -27,6 +27,8 @@
 #include "jslib.h"
 #include "form.h"
 #include <clib/utility_protos.h>
+#include <proto/utility.h>
+#include <stdarg.h>
 
 /*------------------------------------------------------------------------*/
 
@@ -94,6 +96,53 @@ static LIST(Waitrequest) waitrequests;
 
 #define AOFCC_Arexxcmd     (AOFCC_Dummy+64)
 
+struct BoundedFmt
+{
+   UBYTE *buf;
+   long size;
+   long len;
+};
+
+static void PutChBounded(UBYTE ch, APTR data)
+{
+   struct BoundedFmt *bf = (struct BoundedFmt *)data;
+   if(!bf || !bf->buf || bf->size <= 0) return;
+
+   if(bf->len < bf->size - 1)
+   {
+      bf->buf[bf->len++] = ch;
+      bf->buf[bf->len] = '\0';
+   }
+}
+
+static long BVSNPrintf(UBYTE *dst, long dstsize, const UBYTE *fmt, va_list ap)
+{
+   struct BoundedFmt bf;
+
+   if(!dst || dstsize <= 0) return 0;
+   dst[0] = '\0';
+
+   bf.buf  = dst;
+   bf.size = dstsize;
+   bf.len  = 0;
+
+   VNewRawDoFmt((STRPTR)fmt, PutChBounded, (APTR)&bf, ap);
+
+   return bf.len;
+}
+
+static long BSNPrintf(UBYTE *dst, long dstsize, const UBYTE *fmt, ...)
+{
+   va_list ap;
+   long n;
+
+   va_start(ap, fmt);
+   n = BVSNPrintf(dst, dstsize, fmt, ap);
+   va_end(ap);
+
+   return n;
+}
+
 /*------------------------------------------------------------------------*/
 
 /* Error scheme task. The validate field is mis-used as msg id. */
@@ -106,18 +155,31 @@ void Errorschemetask(struct Fetchdriver *fd)
       else scheme=Dupstr(fd->name,-1);
       if(scheme)
       {  if(haiku)
-         {  strcpy(fd->block,"<html>");
+         {  length = BSNPrintf(fd->block, fd->blocksize, "<html>");
             switch(fd->validate)
-            {  case MSG_EPART_NOPROGRAM:strcat(fd->block,HAIKU9);break;
-               case MSG_EPART_NOAWEBLIB:strcat(fd->block,HAIKU14);break;
-               case MSG_EPART_ADDRSCHEME:strcat(fd->block,HAIKU15);break;
+            {  case MSG_EPART_NOPROGRAM:
+                  if(length < fd->blocksize)
+                      length += BSNPrintf(fd->block + length, fd->blocksize - length, "%s", HAIKU9);
+                  break;
+               case MSG_EPART_NOAWEBLIB:
+                  if(length < fd->blocksize)
+                      length += BSNPrintf(fd->block + length, fd->blocksize - length, "%s", HAIKU14);
+                  break;
+               case MSG_EPART_ADDRSCHEME:
+                  if(length < fd->blocksize)
+                      length += BSNPrintf(fd->block + length, fd->blocksize - length, "%s", HAIKU15);
+                  break;
             }
-            length=strlen(fd->block);
          }
          else
-         {  length=sprintf(fd->block,"<html><h1>%s</h1>%s %.1000s<p><strong>",
-               AWEBSTR(MSG_EPART_ERROR),AWEBSTR(MSG_EPART_RETURL),fd->name);
-            length+=sprintf(fd->block+length,AWEBSTR(fd->validate),scheme);
+         {  length = BSNPrintf(fd->block, fd->blocksize,
+                "<html><h1>%s</h1>%s %.1000s<p><strong>",
+                AWEBSTR(MSG_EPART_ERROR), AWEBSTR(MSG_EPART_RETURL), fd->name);
+
+            if(length < fd->blocksize)
+            {  length += BSNPrintf(fd->block + length, fd->blocksize - length,
+                  (const UBYTE *)AWEBSTR(fd->validate), scheme);
+            }
          }
          Updatetaskattrs(
             AOURL_Error,TRUE,
@@ -882,7 +944,6 @@ static long Updatefetch(struct Fetch *fch,struct Amset *ams)
 {  struct TagItem *tag,*tstate=ams->tags;
    BOOL forward=TRUE,dispose=FALSE,retryget=FALSE,statusset=FALSE;
    ULONG netstat=0;
-   UBYTE buf[40];
    ULONG statustag=TAG_IGNORE;
    if(tstate)
    {  while(tag=NextTagItem(&tstate))
@@ -929,6 +990,7 @@ static long Updatefetch(struct Fetch *fch,struct Amset *ams)
                break;
             case AOURL_Status:
                strncpy(fch->statusbuf,(UBYTE *)tag->ti_Data,STATUSBUFSIZE-1);
+               fch->statusbuf[STATUSBUFSIZE-1] = '\0';
                tag->ti_Data=(ULONG)fch->statusbuf;
                statusset=TRUE;
                break;
@@ -986,16 +1048,18 @@ static long Updatefetch(struct Fetch *fch,struct Amset *ams)
    }
    /* Forward this message. Build status text */
    if(forward && fch->sofar && !statusset)
-   {  strcpy(buf,AWEBSTR(MSG_AWEB_BYTESREAD));
+   {
       if(fch->total)
-      {  strcat(buf,": %d/%d");
-         sprintf(fch->statusbuf,buf,fch->sofar,fch->total);
+      {
+          BSNPrintf(fch->statusbuf, STATUSBUFSIZE, "%s: %ld/%ld",
+            AWEBSTR(MSG_AWEB_BYTESREAD), fch->sofar, fch->total);
       }
       else
-      {  strcat(buf,": %d");
-         sprintf(fch->statusbuf,buf,fch->sofar);
+      {
+          BSNPrintf(fch->statusbuf, STATUSBUFSIZE, "%s: %ld",
+            AWEBSTR(MSG_AWEB_BYTESREAD), fch->sofar);
       }
-      statustag=AOURL_Status;
+      statustag = AOURL_Status;
    }
    if(forward)
    {  Asrcupdatetags(fch->url,fch,


### PR DESCRIPTION
## Summary
This PR hardens `fetch.c` against buffer overflows by replacing several unbounded string formatting/copy patterns with a bounded formatter.

## Changes
- Add a small bounded `VNewRawDoFmt`-based formatter helper in `fetch.c` (C89-friendly).
- Use bounded formatting for `Errorschemetask()` HTML output (previously `strcpy/strcat/sprintf` into `fd->block`).
- Ensure `AOURL_Status` copies are always NUL-terminated (`statusbuf[STATUSBUFSIZE-1] = '\0'`).
- Replace `sprintf()` into `statusbuf` with bounded formatting and remove the temporary local `buf[40]`.

## Rationale
`fd->block` and `statusbuf` have fixed sizes. Prior code used unbounded operations that could write past the buffer end in edge cases. This keeps behavior the same while preventing memory corruption.

## Notes
- No functional/UX changes intended; this is a robustness/safety patch only.
- Implementation stays within classic Amiga constraints (no C99, uses `VNewRawDoFmt`).
