### PR TITLE
C89: replace // comments in headers (3.6a6 branch)

### DIFF
--- a/Source/AWebAPL/Include/ezlists.h
+++ b/Source/AWebAPL/Include/ezlists.h
@@ -16,7 +16,7 @@
  *
  **********************************************************************/
 
-// easy lists
+/* easy lists */
 
 #ifndef EZLISTS_H
 #define EZLISTS_H

--- a/Source/AWebAPL/awebcfg.h
+++ b/Source/AWebAPL/awebcfg.h
@@ -149,7 +149,7 @@ extern STRPTR __asm GetString(register __a0 struct LocaleInfo *li,
 extern void *maincatalog;
 extern UBYTE *Getmainstr(ULONG msg);
 
-// Library base pointers are now provided by proto headers
+/* Library base pointers are now provided by proto headers */
 
 extern UBYTE config[];              /* configuration name */
 extern struct Screen *pubscreen;

--- a/Source/AWebAPL/awebjs.h
+++ b/Source/AWebAPL/awebjs.h
@@ -36,10 +36,10 @@
 #include <pragmas/exec_pragmas.h>
 #include <pragmas/locale_pragmas.h>
 
-// #define JSDEBUG
-// #define JSADDRESS
+/* #define JSDEBUG */
+/* #define JSADDRESS */
 
-// #define debug KPrintF
+/* #define debug KPrintF */
 #define debug / ## /KPrintF
 
 #define STRNIEQUAL(a,b,n)  !strnicmp(a,b,n)

--- a/Source/AWebAPL/awebprotos.h
+++ b/Source/AWebAPL/awebprotos.h
@@ -85,7 +85,7 @@ extern BOOL Installtimer(void);
 extern BOOL Installinfo(void);
 extern BOOL Installauthedit(void);
 
-   // Frees all classes
+   /* Frees all classes */
 extern void Freeobject(void);
 
 /*-----------------------------------------------------------------------*/
@@ -112,35 +112,35 @@ extern void Freeapplication(void);
 extern BOOL Initarexx(void);
 extern void Freearexx(void);
 
-   // Open port for this window. returns port name
+   /* Open port for this window. returns port name */
 extern UBYTE *Openarexxport(ULONG windowkey);
 
-   // Close port for this window
+   /* Close port for this window */
 extern void Closearexxport(ULONG windowkey);
 
-   // Send an ARexx command.
+   /* Send an ARexx command. */
 extern void Sendarexxcmd(ULONG windowkey,UBYTE *cmd);
 
-   // Get the port number
+   /* Get the port number */
 extern short Arexxportnr(ULONG windowkey);
 
-   // Reply a stalled Arexx command
+   /* Reply a stalled Arexx command */
 extern void Replyarexxcmd(struct Arexxcmd *ac);
 
-   // Set variable <stem>.<index>[.<field>]
+   /* Set variable <stem>.<index>[.<field>] */
 extern void Setstemvar(struct Arexxcmd *ac,UBYTE *stem,long index,
    UBYTE *field,UBYTE *value);
 
-   // Get variable <stem>.<index>[.<field>]
+   /* Get variable <stem>.<index>[.<field>] */
 extern UBYTE *Getstemvar(struct Arexxcmd *ac,UBYTE *stem,long index,UBYTE *field);
 
-   // Execute one command with parameter substitution
+   /* Execute one command with parameter substitution */
 extern void Execarexxcmd(ULONG windowkey,UBYTE *cmd,UBYTE *argspec,...);
 
-   // Find the port number for this window
+   /* Find the port number for this window */
 extern long Arexxportnumber(ULONG windowkey);
 
-   // Execute one command from support library
+   /* Execute one command from support library */
 extern long Supportarexxcmd(long portnr,UBYTE *cmd,UBYTE *resultbuf,long length);
 
 /*-----------------------------------------------------------------------*/
@@ -150,28 +150,28 @@ extern long Supportarexxcmd(long portnr,UBYTE *cmd,UBYTE *resultbuf,long length)
 extern BOOL Initauthor(void);
 extern void Freeauthor(void);
 
-   // Returns (copy of) known authorization, or a new one
+   /* Returns (copy of) known authorization, or a new one */
 extern struct Authorize *Newauthorize(UBYTE *server,UBYTE *realm);
 extern void Freeauthorize(struct Authorize *auth);
 
-   // Returns guessed authorization, or NULL
+   /* Returns guessed authorization, or NULL */
 extern struct Authorize *Guessauthorize(UBYTE *server);
 
 extern struct Authorize *Dupauthorize(struct Authorize *auth);
 
-   // Start authorization dialog
+   /* Start authorization dialog */
 extern BOOL Doauthorize(struct Authorize *auth,void *fetch);
 
-   // Flush all authorizations
+   /* Flush all authorizations */
 extern void Flushauthor(void);
 
-   // Save authorizations
+   /* Save authorizations */
 extern void Saveauthor(void);
 
-   // Forget authorization details
+   /* Forget authorization details */
 extern void Forgetauthorize(struct Authorize *auth);
 
-   // Set authorization details
+   /* Set authorization details */
 extern void Setauthorize(struct Authorize *auth,UBYTE *userid,UBYTE *passwd);
 
 extern void Authorize(struct Fetchdriver *fd,struct Authorize *auth,BOOL proxy);
@@ -185,153 +185,153 @@ extern BOOL Isopenauthedit(void);
 /*-- aweb ---------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // ensure buffer is large enough to add (size)
+   /* ensure buffer is large enough to add (size) */
 extern BOOL Expandbuffer(struct Buffer *buf,long size);
 
-   // free buffer contents
+   /* free buffer contents */
 extern void Freebuffer(struct Buffer *buf);
 
-   // add string to buffer
+   /* add string to buffer */
 extern BOOL Addtobuffer(struct Buffer *buf,UBYTE *text,long length);
 
-   // insert string into buffer on position (pos)
+   /* insert string into buffer on position (pos) */
 extern BOOL Insertinbuffer(struct Buffer *buf,UBYTE *text,long length,
    long pos);
 
-   // delete characters from buffer
+   /* delete characters from buffer */
 extern void Deleteinbuffer(struct Buffer *buf,long pos,long length);
 
-   // duplicate string (dynamic). If (length)<0, strlen(str) is taken
+   /* duplicate string (dynamic). If (length)<0, strlen(str) is taken */
 extern UBYTE *Dupstr(UBYTE *str,long length);
 
-   // build a HTML tag string from components
+   /* build a HTML tag string from components */
 extern void AddtagstrA(struct Buffer *buf,UBYTE *keywd,USHORT f,ULONG value);
 #define Addtagstr(b,k,f,v) AddtagstrA(b,k,f,(ULONG)(v))
 
-   // copy our pathlist
+   /* copy our pathlist */
 extern long Copypathlist(void);
 extern void Freepathlist(long plbptr);
 
-   // sprintf type but with letter-identified argument specifiers
+   /* sprintf type but with letter-identified argument specifiers */
 extern long Pformatlength(UBYTE *format,UBYTE *argspec,UBYTE **params);
 extern UBYTE *Pformat(UBYTE *buffer,UBYTE *format,UBYTE *argspec,UBYTE **params,BOOL quote);
 
-   // spawn external command. if (del), delete file named (1st param) afterwards
+   /* spawn external command. if (del), delete file named (1st param) afterwards */
 extern BOOL Spawn(BOOL del,UBYTE *cmd,UBYTE *args,UBYTE *argspec,...);
 
-   // display quit requester or quit immediate
+   /* display quit requester or quit immediate */
 extern void Quit(BOOL immediate);
 
-   // Defer iconification
+   /* Defer iconification */
 extern void Iconify(BOOL iconify);
 
-   // Do a SetGadgetAttrs and a RefreshGList if necessary
+   /* Do a SetGadgetAttrs and a RefreshGList if necessary */
 extern void Setgadgetattrs(struct Gadget *gad,struct Window *win,struct Requester *req,...);
 
-   // Get BOOPSI object attribute
+   /* Get BOOPSI object attribute */
 extern long Getvalue(void *gad,ULONG tag);
 
-   // Get GA_Selected gadget attribute
+   /* Get GA_Selected gadget attribute */
 extern BOOL Getselected(struct Gadget *gad);
 
-   // sprintf() with locale support
+   /* sprintf() with locale support */
 extern long LprintfA(UBYTE *buffer,UBYTE *fmt,void *args);
 extern long Lprintf(UBYTE *buffer,UBYTE *fmt,...);
 
-   // sprintf() for locale formatted date
+   /* sprintf() for locale formatted date */
 extern long Lprintdate(UBYTE *buffer,UBYTE *fmt,struct DateStamp *ds);
 
-   // show a requester for low-level error message
+   /* show a requester for low-level error message */
 extern void Lowlevelreq(UBYTE *msg,...);
 
-   // Open classact class
+   /* Open classact class */
 extern struct ClassLibrary *Openclass(UBYTE *name,long version);
 
-   // General clip and unclip functions
+   /* General clip and unclip functions */
 extern ULONG Clipto(struct RastPort *rp,short minx,short miny,short maxx,short maxy);
 extern void Unclipto(ULONG key);
 
-   // Easy Coords fallback interface. Call Clipcoords with your frame and either
-   // an existing Coords or NULL. If NULL, a new Coords will be created and
-   // the rastport will be clipped.
-   // Match every Clipcoords() with an Unclipcoords() call.
+   /* Easy Coords fallback interface. Call Clipcoords with your frame and either */
+   /* an existing Coords or NULL. If NULL, a new Coords will be created and */
+   /* the rastport will be clipped. */
+   /* Match every Clipcoords() with an Unclipcoords() call. */
 extern struct Coords *Clipcoords(void *cframe,struct Coords *coo);
 extern void Unclipcoords(struct Coords *coo);
 
-   // Is character valid in url?
+   /* Is character valid in url? */
 extern BOOL Isurlchar(UBYTE c);
 
-   // Is character really printable?
+   /* Is character really printable? */
 extern BOOL Isprint(UBYTE c);
 
-   // Is character whitespace?
+   /* Is character whitespace? */
 extern BOOL Isspace(UBYTE c);
 
-   // Is character valid in SGML name?
+   /* Is character valid in SGML name? */
 extern BOOL Issgmlchar(UBYTE c);
 
-   // Is character alphabetic (latin1)?
+   /* Is character alphabetic (latin1)? */
 extern BOOL Isalpha(UBYTE c);
 
-   // Is character alphanumeric?
+   /* Is character alphanumeric? */
 extern BOOL Isalnum(UBYTE c);
 
-   // Today's time stamp
+   /* Today's time stamp */
 extern ULONG Today(void);
 
-   // Make datestamp from string
+   /* Make datestamp from string */
 extern ULONG Scandate(UBYTE *buf);
 
-   // Make HTTP date format from stamp. (buf) must be >=30 bytes
+   /* Make HTTP date format from stamp. (buf) must be >=30 bytes */
 extern void Makedate(ULONG stamp, UBYTE *buf);
 
-   // Get the application object
+   /* Get the application object */
 extern struct Aobject *Aweb(void);
 
-   // Safely close a window with shared port
+   /* Safely close a window with shared port */
 extern void Safeclosewindow(struct Window *w);
 
-   // Create a dynamic string with the full name for this url from the save path
+   /* Create a dynamic string with the full name for this url from the save path */
 extern UBYTE *Savepath(void *url);
 
-   // Set a signal processing function
+   /* Set a signal processing function */
 extern void Setprocessfun(short sigbit,void (*fun)(void));
 
-   // get full name in dynamic string. Free yourself after use.
+   /* get full name in dynamic string. Free yourself after use. */
 extern UBYTE *Fullname(UBYTE *name);
 
-   // Check if file is read-only
+   /* Check if file is read-only */
 extern BOOL Readonlyfile(UBYTE *name);
 
-   // One or more layouts have changed
+   /* One or more layouts have changed */
 extern void Changedlayout(void);
 
-   // Flush excess sources when idle
+   /* Flush excess sources when idle */
 extern void Deferflushmem(void);
 
-   // Wait for signals plus extramask, process signals, return on any extramask bit.
+   /* Wait for signals plus extramask, process signals, return on any extramask bit. */
 extern ULONG Waitprocessaweb(ULONG extramask);
 
-   // Queue this object to receive AOM_SET asap with this AOBJ_Queueid.
-   // Set queueid to 0 to cancel.
+   /* Queue this object to receive AOM_SET asap with this AOBJ_Queueid. */
+   /* Set queueid to 0 to cancel. */
 extern void Queuesetmsg(void *object,ULONG queueid);
 extern void Queuesetmsgdata(void *object,ULONG queueid,ULONG userdata);
 
-   // Open aweblib module with exact version and revision
+   /* Open aweblib module with exact version and revision */
 extern struct Library *Openaweblib(UBYTE *name);
 
-   // Open the awebjs library if not already open
+   /* Open the awebjs library if not already open */
 extern struct Library *Openjslib(void);
 
-   // Load requester
+   /* Load requester */
 extern void Openloadreq(struct Screen *screen);
 extern void Setloadreqstate(USHORT state);
 extern void Setloadreqlevel(long ready,long total);
 
-   // Return TRUE if less than 4 kB left on the stack
+   /* Return TRUE if less than 4 kB left on the stack */
 extern BOOL Stackoverflow(void);
 
-   // Return TRUE if AWeb owns the active window
+   /* Return TRUE if AWeb owns the active window */
 extern BOOL Awebactive(void);
 
 #ifdef BETAKEYFILE
@@ -342,23 +342,23 @@ extern void Mprintf(UBYTE *fmt,...);
 /*-- body ---------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Find the owner FRAME object
+   /* Find the owner FRAME object */
 extern void *Bodyframe(void *body);
 
-   // Get background info, and forward to owner Framecoords()
+   /* Get background info, and forward to owner Framecoords() */
 extern void Bodycoords(void *body,struct Coords *coo);
 
 /*-----------------------------------------------------------------------*/
 /*-- boopsi -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // initialize classes
+   /* initialize classes */
 extern BOOL Initboopsi(void);
 
-   // close classes
+   /* close classes */
 extern void Freeboopsi(void);
 
-   // return class pointer
+   /* return class pointer */
 extern void *Gadimgclass(void);
 extern void *Stagadclass(void);
 extern void *Ledgadclass(void);
@@ -367,7 +367,7 @@ extern void *Ledgadclass(void);
 /*-- cabrowse -----------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Open, close the cache browser
+   /* Open, close the cache browser */
 extern void Opencabrowse(void);
 extern void Closecabrowse(void);
 
@@ -377,10 +377,10 @@ extern BOOL Isopencabrowse(void);
 /*-- clip ---------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Write a string to the clipboard
+   /* Write a string to the clipboard */
 extern void Clipcopy(UBYTE *text,long length);
 
-   // Read a string from the clipboard. Returns nr of bytes read (or <0 if error)
+   /* Read a string from the clipboard. Returns nr of bytes read (or <0 if error) */
 extern long Clippaste(UBYTE *buf,long length);
 
 /*-----------------------------------------------------------------------*/
@@ -390,20 +390,20 @@ extern long Clippaste(UBYTE *buf,long length);
 extern BOOL Initcookie(void);
 extern void Freecookie(void);
 
-   // Store info from Set-Cookie: line. originator is URL, cookiespec is
-   // data after Set-Cookie:
+   /* Store info from Set-Cookie: line. originator is URL, cookiespec is */
+   /* data after Set-Cookie: */
 extern void Storecookie(UBYTE *originator,UBYTE *cookiespec,ULONG serverdate);
 
-   // Build a Cookie: header string terminated by CRLF
+   /* Build a Cookie: header string terminated by CRLF */
 extern UBYTE *Findcookies(UBYTE *url,BOOL secure);
 
-   // Build the JS cookie string */
+   /* Build the JS cookie string */ */
 extern UBYTE *Getjcookies(UBYTE *url);
 
-   // Flush all cookies beyond this memory limit
+   /* Flush all cookies beyond this memory limit */
 extern void Flushcookies(long max);
 
-   // Get/Set all cookies for ARexx
+   /* Get/Set all cookies for ARexx */
 extern void Getrexxcookies(struct Arexxcmd *ac,UBYTE *stem);
 extern void Setrexxcookies(struct Arexxcmd *ac,UBYTE *stem,BOOL add);
 
@@ -411,17 +411,17 @@ extern void Setrexxcookies(struct Arexxcmd *ac,UBYTE *stem,BOOL add);
 /*-- copyjs -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Add the JS Image() constructor to this object */
+   /* Add the JS Image() constructor to this object */ */
 extern void Addimageconstructor(struct Jcontext *jc,struct Jobject *parent);
 
 /*-----------------------------------------------------------------------*/
 /*-- element ------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Calculate text length, working around word arithmatic bug in OS
+   /* Calculate text length, working around word arithmatic bug in OS */
 extern long Textlength(struct RastPort *rp,UBYTE *text,long count);
 
-   // Calculate text length, and return real pixel length in (extent)
+   /* Calculate text length, and return real pixel length in (extent) */
 extern long Textlengthext(struct RastPort *rp,UBYTE *text,long count,long *extent);
 
 /*-----------------------------------------------------------------------*/
@@ -430,50 +430,50 @@ extern long Textlengthext(struct RastPort *rp,UBYTE *text,long count,long *exten
 
 extern void Processwindow(void);
 
-   // relayout and render changed frames
+   /* relayout and render changed frames */
 extern void Doupdateframes(void);
 
-   // re-display all windows
+   /* re-display all windows */
 extern void Redisplayall(void);
 
-   // set load images menu checkmark, start loading for all windows.
-   // also set backround images and sound checkmarks
+   /* set load images menu checkmark, start loading for all windows. */
+   /* also set backround images and sound checkmarks */
 extern void Setloadimg(void);
 extern void Setdocolors(void);
 extern void Setdobgsound(void);
 
-   // input a new url in a frame in this window
+   /* input a new url in a frame in this window */
 extern void Inputwindoc(void *win,struct Url *url,UBYTE *fragment,UBYTE *frameid);
 extern void Inputwindocnoref(void *win,struct Url *url,UBYTE *fragment,UBYTE *frameid);
 extern void Inputwindocreload(void *win,struct Url *url,UBYTE *fragment,UBYTE *frameid);
 
-   // Input a new url the smart way
+   /* Input a new url the smart way */
 extern void Inputwindocsmart(void *win,UBYTE *url,UBYTE *frameid);
 
-   // Go forward or backward in history
+   /* Go forward or backward in history */
 extern void Gohistory(void *win,long n);
 
-   // Process refresh events
+   /* Process refresh events */
 extern void Refreshevents(void);
 
-   // Open a file requester for open with optional pattern
+   /* Open a file requester for open with optional pattern */
 extern void Openfilereq(void *win,UBYTE *pattern);
 
-   // Open URL requester for open
+   /* Open URL requester for open */
 extern void Openurlreq(void *win);
 
 /*-----------------------------------------------------------------------*/
 /*-- form ---------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Copy (p) to (buf), URLencoded if necessary
+   /* Copy (p) to (buf), URLencoded if necessary */
 extern void Urlencode(struct Buffer *buf,UBYTE *p,long len);
 
 /*-----------------------------------------------------------------------*/
 /*-- frame --------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // get coordinate offsets for this frame
+   /* get coordinate offsets for this frame */
 extern void Framecoords(void *frame,struct Coords *coo);
 
 extern void Erasebg(void *frame,struct Coords *coo,long xmin,long ymin,long xmax,long ymax);
@@ -494,41 +494,41 @@ extern UBYTE *Rexxframeid(void *frame);
 /*-- framejs ------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Run JavaScript program. Use frame's object if jthisp is NULL or points
-   // to NULL. A pointer is used because the actual object may not yet exist
-   // when this function is called, in which case it is created from within
-   // this function.
-   // Returns TRUE if failed, FALSE means run ok and cancel default action.
+   /* Run JavaScript program. Use frame's object if jthisp is NULL or points */
+   /* to NULL. A pointer is used because the actual object may not yet exist */
+   /* when this function is called, in which case it is created from within */
+   /* this function. */
+   /* Returns TRUE if failed, FALSE means run ok and cancel default action. */
 extern BOOL Runjavascript(void *frame,UBYTE *script,struct Jobject **jthisp);
 
-   // Same but suppress banner windows if so configured
+   /* Same but suppress banner windows if so configured */
 extern BOOL Runjsnobanners(void *frame,UBYTE *script,struct Jobject **jthisp);
 
-   // Same as above but the with object is asked for an extra JS object
-   // to be included in the global with scope
+   /* Same as above but the with object is asked for an extra JS object */
+   /* to be included in the global with scope */
 BOOL Runjavascriptwith(struct Frame *fr,UBYTE *script,struct Jobject **jthisp,
    struct Aobject *with);
 
-   // Get the frame object from the JS context
+   /* Get the frame object from the JS context */
 extern void *Getjsframe(struct Jcontext *jc);
 
-   // Get the document (copydriver) object from the JS context
+   /* Get the document (copydriver) object from the JS context */
 extern void *Getjsdocument(struct Jcontext *jc);
 
-   // Get the current JS generated text if it is for this url.
-   // Returns TRUE if text is complete (closed). Bufferp will be set to
-   // NULL if no text is available.
+   /* Get the current JS generated text if it is for this url. */
+   /* Returns TRUE if text is complete (closed). Bufferp will be set to */
+   /* NULL if no text is available. */
 extern BOOL Getjsgeneratedtext(UBYTE *urlname,UBYTE **bufferp);
 
-   // Get the current URL name (static) in the frame that is running the JS program
-   // In case of redirected URL, this is the actual URL of the source.
+   /* Get the current URL name (static) in the frame that is running the JS program */
+   /* In case of redirected URL, this is the actual URL of the source. */
 extern UBYTE *Getjscurrenturlname(struct Jcontext *jc);
 
 /*-----------------------------------------------------------------------*/
 /*-- hotlist ------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // open, close the window
+   /* open, close the window */
 extern void Hotlistviewer(ULONG windowkey);
 extern void Hotlistmanager(ULONG windowkey);
 extern void Closehotlistviewer(void);
@@ -537,22 +537,22 @@ extern void Closehotlistmanager(void);
 extern BOOL Isopenhotlistviewer(void);
 extern BOOL Isopenhotlistmanager(void);
 
-   // build html formatted hotlist, write to temp file
+   /* build html formatted hotlist, write to temp file */
 extern void Buildhtmlhotlist(void *tf);
 
-   // Add doc to hotlist
+   /* Add doc to hotlist */
 extern void Addtohotlist(void *url,UBYTE *title,UBYTE *group);
 
-   // Set hotlist name
+   /* Set hotlist name */
 extern void Sethotlistname(UBYTE *name);
 
-   // Save hotlist if changed
+   /* Save hotlist if changed */
 extern void Savehotlist(void);
 
-   // Restore hotlist
+   /* Restore hotlist */
 extern void Restorehotlist(void);
 
-   // Get, set hotlist contents (ARexx)
+   /* Get, set hotlist contents (ARexx) */
 extern void Gethotlistcontents(struct Arexxcmd *ac,UBYTE *stem,BOOL groupsonly);
 extern void Sethotlistcontents(struct Arexxcmd *ac,UBYTE *stem);
 
@@ -563,17 +563,17 @@ extern void Sethotlistcontents(struct Arexxcmd *ac,UBYTE *stem);
 extern BOOL Inithttp(void);
 extern void Freehttp(void);
 
-   // http protocol subtask
+   /* http protocol subtask */
 extern void Httptask(struct Fetchdriver *fd);
 
-   // keep-alive connection management
+   /* keep-alive connection management */
 extern void CloseIdleKeepAliveConnections(void);
 
 /*-----------------------------------------------------------------------*/
 /*-- info ---------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Returns info window's dimensions
+   /* Returns info window's dimensions */
 extern void Getinfodim(short *x,short *y,short *w,short *h);
 
 /*-----------------------------------------------------------------------*/
@@ -583,7 +583,7 @@ extern void Getinfodim(short *x,short *y,short *w,short *h);
 extern short Initkey(void);
 extern void Freekey(void);
 
-   // return dynamic string
+   /* return dynamic string */
 extern unsigned char *Aboutstring(void);
 
 extern BOOL Registered(void);
@@ -594,7 +594,7 @@ extern void Checkregisterinfo(void);
 /*-- local --------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // local file protocol subtask
+   /* local file protocol subtask */
 extern void Localfiletask(struct Fetchdriver *fd);
 extern void Cidurltask(struct Fetchdriver *fd);
 extern void Dataurltask(struct Fetchdriver *fd);
@@ -613,13 +613,13 @@ extern STRPTR __asm GetString(register __a0 struct LocaleInfo *li,
 extern BOOL Initmemory(void);
 extern void Freememory(void);
 
-   // allocate in private pool. If pool==NULL, allocate unpooled
+   /* allocate in private pool. If pool==NULL, allocate unpooled */
 extern void *Pallocmem(long size,ULONG flags,void *pool);
 
-   // allocate pooled memory
+   /* allocate pooled memory */
 extern void *Allocmem(long size,ULONG flags);
 
-   // free memory, works for all pools and unpooled memory
+   /* free memory, works for all pools and unpooled memory */
 extern void Freemem(void *mem);
 
 /*-----------------------------------------------------------------------*/
@@ -629,26 +629,26 @@ extern void Freemem(void *mem);
 extern BOOL Initmime(void);
 extern void Freemime(void);
 
-   // delete all known mimetypes
+   /* delete all known mimetypes */
 extern void Reinitmime(void);
 
-   // add a mimetype. Will modify (*exts).
+   /* add a mimetype. Will modify (*exts). */
 extern void Addmimetype(UBYTE *type,UBYTE *exts,USHORT driver,UBYTE *cmd,UBYTE *args);
 
-   // Find full MIME type from name
+   /* Find full MIME type from name */
 extern UBYTE *Mimetypefromext(UBYTE *name);
 
-   // Check if text MIME type is acceptable, returns FALSE if not.
+   /* Check if text MIME type is acceptable, returns FALSE if not. */
 extern BOOL Checkmimetype(UBYTE *data,long length,UBYTE *type);
 
-   // Find full MIME type from data contents, obeying default type
+   /* Find full MIME type from data contents, obeying default type */
 extern UBYTE *Mimetypefromdata(UBYTE *data,long length,UBYTE *deftype);
 
-   // Get mime driver (MIMEDRV_xxx) for this mime type
-   // Name of program or plugin returned in *name, args in *args
+   /* Get mime driver (MIMEDRV_xxx) for this mime type */
+   /* Name of program or plugin returned in *name, args in *args */
 extern ULONG Getmimedriver(UBYTE *mimetype,UBYTE **name,UBYTE **args);
 
-   // Check if mime type is XBM image
+   /* Check if mime type is XBM image */
 extern BOOL Isxbm(UBYTE *mimetype);
 
 /*-----------------------------------------------------------------------*/
@@ -658,35 +658,35 @@ extern BOOL Isxbm(UBYTE *mimetype);
 extern BOOL Initnameserv(void);
 extern void Freenameserv(void);
 
-   // Look up host name
+   /* Look up host name */
 extern struct hostent *Lookup(UBYTE *name,struct Library *base);
 
 /*-----------------------------------------------------------------------*/
 /*-- netstat ------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Open,close netstat window
+   /* Open,close netstat window */
 extern void Opennetstat(void);
 extern void Closenetstat(void);
 
 extern BOOL Isopennetstat(void);
 
-   // Add process, returns key
+   /* Add process, returns key */
 extern void *Addnetstat(void *fetch,UBYTE *url,ULONG status,BOOL cps);
 
-   // Change process
+   /* Change process */
 extern void Chgnetstat(void *key,ULONG status,ULONG read,ULONG total);
 
-   // Returns netstat window's dimensions
+   /* Returns netstat window's dimensions */
 extern void Getnetstatdim(short *x,short *y,short *w,short *h);
 
-   // Set new preferred dimensions
+   /* Set new preferred dimensions */
 extern void Setnetstatdim(short x,short y,short w,short h);
 
-   // Cancel all transfers
+   /* Cancel all transfers */
 extern void Cancelnetstatall(void);
 
-   // Get transfers in ARexx stem
+   /* Get transfers in ARexx stem */
 extern void Gettransfers(struct Arexxcmd *ac,UBYTE *stem);
 
 /*-----------------------------------------------------------------------*/
@@ -713,17 +713,17 @@ extern void Addtonocookie(UBYTE *name);
 
 extern void Jsetupprefs(struct Jcontext *jc,struct Jobject *jnav);
 
-   // Find matching font from font alias list.
+   /* Find matching font from font alias list. */
 extern struct Fontprefs *Matchfont(UBYTE *face,short size,BOOL fixed);
 
 /*-----------------------------------------------------------------------*/
 /*-- print --------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Start print for this window's contents
+   /* Start print for this window's contents */
 extern void Printdoc(void *win,BOOL debug);
 
-   // Start print from ARexx. Returns TRUE if success.
+   /* Start print from ARexx. Returns TRUE if success. */
 extern BOOL Printarexx(void *win,long scale,BOOL center,BOOL ff,BOOL bg,
    struct Arexxcmd *wait,BOOL debug);
 
@@ -734,10 +734,10 @@ extern BOOL Printarexx(void *win,long scale,BOOL center,BOOL ff,BOOL bg,
 extern BOOL Initrequest(void);
 extern void Freerequest(void);
 
-   // Close all sync requesters
+   /* Close all sync requesters */
 extern void Closerequests(void);
 
-   // Open requester
+   /* Open requester */
 extern void Aboutreq(UBYTE *portname);
 extern void Closeabout(void);
 extern BOOL Quitreq(void);
@@ -745,42 +745,42 @@ extern void Unregreq(void);
 
 extern BOOL Isopenabout(void);
 
-   // Open general requester. Frees (text) afterwards. (Unless FALSE return)
+   /* Open general requester. Frees (text) afterwards. (Unless FALSE return) */
 extern BOOL Asyncrequest(UBYTE *title,UBYTE *text,UBYTE *label,requestfunc *f,void *data);
 
-   // Same, but add button "Copy url to clipboard"
+   /* Same, but add button "Copy url to clipboard" */
 extern BOOL Asyncrequestcc(UBYTE *title,UBYTE *text,UBYTE *label,requestfunc *f,
    void *data,UBYTE *url);
 
-   // Open general prompt requester. Frees (text) afterwards. (Unless FALSE return)
-   // (string) must be a buffer of at least 128 bytes where the result is copied.
+   /* Open general prompt requester. Frees (text) afterwards. (Unless FALSE return) */
+   /* (string) must be a buffer of at least 128 bytes where the result is copied. */
 extern BOOL Asyncpromptrequest(UBYTE *title,UBYTE *text,UBYTE *label,requestfunc *f,
    void *data,UBYTE *string);
 
-   // Show synchroneous requester, return gadget id (1,2,3,0)
+   /* Show synchroneous requester, return gadget id (1,2,3,0) */
 extern long Syncrequest(UBYTE *title,UBYTE *text,UBYTE *labels,long delay);
 
-   // Same, but add button "Copy url to clipboard"
+   /* Same, but add button "Copy url to clipboard" */
 extern long Syncrequestcc(UBYTE *title,UBYTE *text,UBYTE *labels,UBYTE *url);
 
-   // Synchroneous text prompt requester. Returns dynamic string or NULL.
+   /* Synchroneous text prompt requester. Returns dynamic string or NULL. */
 extern UBYTE *Promptrequest(UBYTE *text,UBYTE *defstr);
 
-   // General cancellable progress requester
+   /* General cancellable progress requester */
 extern struct Progressreq *Openprogressreq(UBYTE *labeltext);
 extern void Setprogressreq(struct Progressreq *pr,long level,long max);
 extern BOOL Checkprogressreq(struct Progressreq *pr);
 extern void Closeprogressreq(struct Progressreq *pr);
 extern void Progresstofront(struct Progressreq *pr);
 
-   // Demo annoy requester
+   /* Demo annoy requester */
 extern void Demorequest(void);
 
 /*-----------------------------------------------------------------------*/
 /*-- saveiff ------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Save a copy of this window as IFF ILBM
+   /* Save a copy of this window as IFF ILBM */
 extern void Saveasiff(void *win,UBYTE *name,BOOL noicon,struct Arexxcmd *wait);
 
 /*-----------------------------------------------------------------------*/
@@ -797,7 +797,7 @@ extern void Closesearch(void *win);
 /*-- select -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Add JS Object() constructor
+   /* Add JS Object() constructor */
 extern void Addoptionconstructor(struct Jcontext *jc,struct Jobject *parent);
 
 /*-----------------------------------------------------------------------*/
@@ -824,19 +824,19 @@ extern BOOL Inittcp(void);
 extern void Freetcp(void);
 extern void Freeamissl(void);
 
-   // Open TCP library. Returns AwebTcpBase if successful.
-   // Doesn't auto connect if (autocon) is FALSE
+   /* Open TCP library. Returns AwebTcpBase if successful. */
+   /* Doesn't auto connect if (autocon) is FALSE */
 extern struct Library *Opentcp(struct Library **base,struct Fetchdriver *fd,BOOL autocon);
 
 /*-----------------------------------------------------------------------*/
 /*-- tcperr -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // build and send html-formatted error message
+   /* build and send html-formatted error message */
 extern void Tcperror(struct Fetchdriver *fd,ULONG err,...);
 extern void TcperrorA(struct Fetchdriver *fd,ULONG err,ULONG *args);
 
-   // build and send message
+   /* build and send message */
 extern void Tcpmessage(struct Fetchdriver *fd,ULONG msg,...);
 extern void TcpmessageA(struct Fetchdriver *fd,ULONG msg,ULONG *args);
 
@@ -844,13 +844,13 @@ extern void TcpmessageA(struct Fetchdriver *fd,ULONG msg,ULONG *args);
 /*-- tooltip ------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Set tooltip text and location. Text must be dynamic; will be taken over.
+   /* Set tooltip text and location. Text must be dynamic; will be taken over. */
 extern void Tooltip(UBYTE *text,long mousex,long mousey);
 
-   // Set tooltip location with same text
+   /* Set tooltip location with same text */
 extern void Tooltipmove(long mousex,long mousey);
 
-   // Final cleanup of tooltip
+   /* Final cleanup of tooltip */
 extern void Freetooltip(void);
 
 /*-----------------------------------------------------------------------*/
@@ -865,41 +865,41 @@ extern void Initialrequester(void (*about)(UBYTE *),UBYTE *p);
 /*-- window -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Rebuild the user button bar in all windows
+   /* Rebuild the user button bar in all windows */
 extern void Rebuildallbuttons(void);
 
-   // Close and re-open all windows
+   /* Close and re-open all windows */
 extern void Reopenallwindows(void);
 
-   // Set or clear the busy pointer for all windows
+   /* Set or clear the busy pointer for all windows */
 extern void Busypointer(BOOL busy);
 
-   // Setup javascript environment for all windows
+   /* Setup javascript environment for all windows */
 extern void Jsetupallwindows(struct Jcontext *jc);
 
-   // Open a new window in JavaScript. Returns JS object.
+   /* Open a new window in JavaScript. Returns JS object. */
 extern void *Jopenwindow(struct Jcontext *jc,struct Jobject *opener,
    UBYTE *urlname,UBYTE *name,UBYTE *spec,struct Awindow *oldwin);
 
-   // Close this window in JavaScript.
+   /* Close this window in JavaScript. */
 extern void Jclosewindow(void *win);
 
-   // Check if any URL is inputting for this window and en/disable cancel gadget
-   // Call this whenever a fetch starts or ends.
+   /* Check if any URL is inputting for this window and en/disable cancel gadget */
+   /* Call this whenever a fetch starts or ends. */
 extern void Inputallwindows(BOOL input);
 
 /*-----------------------------------------------------------------------*/
 /*-- whiswin ------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Open, close history window
+   /* Open, close history window */
 extern void Openwhiswindow(void *whis,long windownr);
 extern void Closewhiswindow(void);
 
-   // Window history has changed
+   /* Window history has changed */
 extern void Changewhiswindow(long windownr);
 
-   // Set new current winhis in history window
+   /* Set new current winhis in history window */
 extern void Setwhiswindow(void *whis);
 
 extern BOOL Isopenwhiswindow(void);
@@ -908,21 +908,21 @@ extern BOOL Isopenwhiswindow(void);
 /*-- winhis -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Get ARexx history
+   /* Get ARexx history */
 extern void Historyarexx(struct Arexxcmd *ac,long *windownr,BOOL mainline,UBYTE *stem);
 
 /*-----------------------------------------------------------------------*/
 /*-- winrexx ------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // do arexx command. Returns TRUE if done with the command
+   /* do arexx command. Returns TRUE if done with the command */
 extern BOOL Doarexxcmd(struct Arexxcmd *ac);
 
 /*-----------------------------------------------------------------------*/
 /*-- xaweb --------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // internal protocol subtask
+   /* internal protocol subtask */
 extern void Xawebtask(struct Fetchdriver *fd);
 
 /*-----------------------------------------------------------------------*/

--- a/Source/AWebAPL/ezlists.h
+++ b/Source/AWebAPL/ezlists.h
@@ -16,7 +16,7 @@
  *
  **********************************************************************/
 
-// easy lists
+/* easy lists */
 
 #ifndef EZLISTS_H
 #define EZLISTS_H

--- a/Source/AWebAPL/haiku.h
+++ b/Source/AWebAPL/haiku.h
@@ -19,90 +19,90 @@
 
 #ifndef DEMOVERSION
 
-//1: about req
+/*1: about req */
 #define HAIKU1 (UBYTE *)" \n \nA web suddenly,\nForty years meditation\nMinds awaken, free"
 
-//2: quit warning
+/*2: quit warning */
 #define HAIKU2 (UBYTE *)"Last window was closed.\nDo you want to quit AWeb?\nMake up your mind now."
 
-//3: EPART_NOLIB
+/*3: EPART_NOLIB */
 #define HAIKU3 (UBYTE *)"Oh, the World Wide Web<br>Is so near and yet so far<br>Without TCP."
 
-//4: EPART_NOHOST
+/*4: EPART_NOHOST */
 #define HAIKU4 (UBYTE *)"A host with this name<br>Might exist somewhere indeed,<br>But I can't find it."
 
-//5: EPART_NOCONNECT
+/*5: EPART_NOCONNECT */
 #define HAIKU5 (UBYTE *)"The Internet links<br>Countless computers but one:<br>This connection failed."
 
-//25: EPART_NOCONNECT_TIMEOUT
+/*25: EPART_NOCONNECT_TIMEOUT */
 #define HAIKU25 (UBYTE *)"Time passed slowly by,<br>Waiting for a connection,<br>But it never came."
 
-//26: EPART_NOCONNECT_REFUSED
+/*26: EPART_NOCONNECT_REFUSED */
 #define HAIKU26 (UBYTE *)"The server said no,<br>Refusing to let you in,<br>Connection denied."
 
-//27: EPART_NOCONNECT_RESET
+/*27: EPART_NOCONNECT_RESET */
 #define HAIKU27 (UBYTE *)"Connection was cut,<br>Reset by the other side,<br>Try again later."
 
-//28: EPART_NOCONNECT_UNREACH
+/*28: EPART_NOCONNECT_UNREACH */
 #define HAIKU28 (UBYTE *)"The network is far,<br>Unreachable from here now,<br>Check your connection."
 
-//29: EPART_NOCONNECT_HOSTUNREACH
+/*29: EPART_NOCONNECT_HOSTUNREACH */
 #define HAIKU29 (UBYTE *)"The host is distant,<br>No route can reach it from here,<br>Try another way."
 
-//6: EPART_NOFILE
+/*6: EPART_NOFILE */
 #define HAIKU6 (UBYTE *)"So big a hard disk,<br>But yet a file with this name<br>Is nowhere on it."
 
-//7: EPART_XAWEB
+/*7: EPART_XAWEB */
 #define HAIKU7 (UBYTE *)"X-aweb is fine,<br>But what followed it is not:<br>Please choose something else."
 
-//8: EPART_NOLOGIN
+/*8: EPART_NOLOGIN */
 #define HAIKU8 (UBYTE *)"Was it a typo<br>Or did you try something bad:<br>Login was denied."
 
-//9: EPART_NOPROGRAM:
+/*9: EPART_NOPROGRAM: */
 #define HAIKU9 (UBYTE *)"I'd like to obey<br>But I must know the program;<br>Without it won't go."
 
-//10: Unknown MIME type
+/*10: Unknown MIME type */
 #define HAIKU10 (UBYTE *)"Wonderful MIME type,\nBut what should I do with it:\nSave it or leave it?"
 
-//11: Can't make SSL connection
+/*11: Can't make SSL connection */
 #define HAIKU11 (UBYTE *)"SSL is nice,\nBut some sites don't support it;\nThis is one of them."
 
-//12: No SSL supported
+/*12: No SSL supported */
 #define HAIKU12 (UBYTE *)"Want security?\nThen you need the libraries,\nOr else it won't work."
 
-//13: Certificate not verified
+/*13: Certificate not verified */
 #define HAIKU13 (UBYTE *)"Nice certificate,\nBut I can't verify it\nSo who is this guy?"
 
-//14: EPART_NOAWEBLIB
+/*14: EPART_NOAWEBLIB */
 #define HAIKU14 (UBYTE *)"What the heck is wrong?<br>Did you mess with aweblibs,<br>There is one missing!"
 
-//15: EPART_ERRSCHEME
+/*15: EPART_ERRSCHEME */
 #define HAIKU15 (UBYTE *)"A rich fantasy!<br>Please restrict your URLs<br>To known address schemes"
 
-//16: Form unsecure warning
+/*16: Form unsecure warning */
 #define HAIKU16 (UBYTE *)"The things you typed here\nAre sent with no protection,\nUnless you cancel."
 
-//17: Del all images?
+/*17: Del all images? */
 #define HAIKU17 (UBYTE *)"Too many pictures\nFilling up the cache in vain\nSo they will be gone."
 
-//18: Del all documents?
+/*18: Del all documents? */
 #define HAIKU18 (UBYTE *)"Every document\nWill be gone from the cache\nWhen I am ready."
 
-//19: Del everything?
+/*19: Del everything? */
 #define HAIKU19 (UBYTE *)"Everything is void,\nEspecially the cached files,\nIf I continue."
 
-//20: Cleanup warning
+/*20: Cleanup warning */
 #define HAIKU20 (UBYTE *)"Cleaning up the cache\nWill delete all foreign files.\nShould I continue?"
 
-//21: Stop TCP too?
+/*21: Stop TCP too? */
 #define HAIKU21 (UBYTE *)"The TCP stack,\nCan't see any use for it,\nSo should I stop it?"
 
-//22: Incomplete file
+/*22: Incomplete file */
 #define HAIKU22 (UBYTE *)"File is incomplete:\nGot less bytes than expected.\nBeautiful bytes, though!"
 
-//23
+/*23 */
 
-//24: Can't close screen
+/*24: Can't close screen */
 #define HAIKU24 (UBYTE *)"Although I'd like to,\nI can't close the screen right now:\nWindows are open."
 
 #else

--- a/Source/AWebAPL/jprotos.h
+++ b/Source/AWebAPL/jprotos.h
@@ -22,23 +22,23 @@
 /*-- jslib --------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Duplicate string
+   /* Duplicate string */
 extern UBYTE *Jdupstr(UBYTE *str,long len,void *pool);
 
-   // Dynamic buffer, text is kept null-terminated
+   /* Dynamic buffer, text is kept null-terminated */
 extern struct Jbuffer *Newjbuffer(void *pool);
 extern void Freejbuffer(struct Jbuffer *jb);
 extern void Addtojbuffer(struct Jbuffer *jb,UBYTE *text,long length);
 
-   // Show error. Returns true if all errors are to be ignored cq debugger wanted.
-   // Set pos to <0 to show a runtime error requester.
+   /* Show error. Returns true if all errors are to be ignored cq debugger wanted. */
+   /* Set pos to <0 to show a runtime error requester. */
 extern BOOL Errorrequester(struct Jcontext *jc,long lnr,UBYTE *line,
    long pos,UBYTE *msg,UBYTE **args);
 
-   // Call feedback. Returns TRUE if continue, FALSE if break.
+   /* Call feedback. Returns TRUE if continue, FALSE if break. */
 extern BOOL Feedback(struct Jcontext *jc);
 
-   // Return TRUE if caller owns the active window
+   /* Return TRUE if caller owns the active window */
 extern BOOL Calleractive(void);
 
 /*-----------------------------------------------------------------------*/
@@ -47,16 +47,16 @@ extern BOOL Calleractive(void);
 
 extern void Initarray(struct Jcontext *jc);
 
-   // Create a new empty Array object, Useobject() it once.
+   /* Create a new empty Array object, Useobject() it once. */
 extern struct Jobject *Newarray(struct Jcontext *jc);
 
-   // Find the nth array element, or NULL
+   /* Find the nth array element, or NULL */
 extern struct Variable *Arrayelt(struct Jobject *jo,long n);
 
-   // Add an element to this array
+   /* Add an element to this array */
 extern struct Variable *Addarrayelt(struct Jcontext *jc,struct Jobject *jo);
 
-   // Tests if this object is an array
+   /* Tests if this object is an array */
 extern BOOL Isarray(struct Jobject *jo);
 
 /*-----------------------------------------------------------------------*/
@@ -65,33 +65,33 @@ extern BOOL Isarray(struct Jobject *jo);
 
 extern void Initboolean(struct Jcontext *jc);
 
-   // Create a new Boolean object, Useobject() it once.
+   /* Create a new Boolean object, Useobject() it once. */
 extern struct Jobject *Newboolean(struct Jcontext *jc,BOOL bvalue);
 
 /*-----------------------------------------------------------------------*/
 /*-- jcomp --------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Compile the source and construct an element tree
+   /* Compile the source and construct an element tree */
 extern void Jcompile(struct Jcontext *jc,UBYTE *source);
 
-   // Compile this source and make it into a function object.
+   /* Compile this source and make it into a function object. */
 struct Jobject *Jcompiletofunction(struct Jcontext *jc,UBYTE *source,UBYTE *name);
 
-   // Decompile the source
+   /* Decompile the source */
 extern struct Jbuffer *Jdecompile(struct Jcontext *jc,struct Element *elt);
 
-   // Dispose this element
+   /* Dispose this element */
 extern void Jdispose(struct Element *elt);
 
 /*-----------------------------------------------------------------------*/
 /*-- jdata --------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Call this property function
+   /* Call this property function */
 extern BOOL Callproperty(struct Jcontext *jc,struct Jobject *jo,UBYTE *name);
 
-   // Value processing
+   /* Value processing */
 extern void Clearvalue(struct Value *v);
 extern void Asgvalue(struct Value *to,struct Value *from);
 extern void Asgnumber(struct Value *to,UBYTE attr,double n);
@@ -100,41 +100,41 @@ extern void Asgstring(struct Value *to,UBYTE *s,void *pool);
 extern void Asgobject(struct Value *to,struct Jobject *jo);
 extern void Asgfunction(struct Value *to,struct Jobject *f,struct Jobject *fthis);
 
-   // WARNING: Tostring() cannot be called for ex->val directly.
+   /* WARNING: Tostring() cannot be called for ex->val directly. */
 extern void Tostring(struct Value *v,struct Jcontext *jc);
 extern void Tonumber(struct Value *v,struct Jcontext *jc);
 extern void Toboolean(struct Value *v,struct Jcontext *jc);
 extern void Toobject(struct Value *v,struct Jcontext *jc);
 extern void Tofunction(struct Value *v,struct Jcontext *jc);
 
-   // Default toString property function
+   /* Default toString property function */
 extern void Defaulttostring(struct Jcontext *jc);
 
-   // Variables
+   /* Variables */
 extern struct Variable *Newvar(UBYTE *name,void *pool);
 extern void Disposevar(struct Variable *var);
 
-   // Objects
+   /* Objects */
 extern struct Jobject *Newobject(struct Jcontext *jc);
 extern void Disposeobject(struct Jobject *jo);
 extern void Clearobject(struct Jobject *jo,UBYTE **except);
 extern struct Variable *Addproperty(struct Jobject *jo,UBYTE *name);
 extern struct Variable *Findproperty(struct Jobject *jo,UBYTE *name);
 
-   // Objhook for .prototype
+   /* Objhook for .prototype */
 extern BOOL Prototypeohook(struct Objhookdata *h);
 
-   // Variable hook for .prototype properties
+   /* Variable hook for .prototype properties */
 extern BOOL Protopropvhook(struct Varhookdata *h);
 
-   // General hook function for constants (that cannot change their value)
+   /* General hook function for constants (that cannot change their value) */
 extern BOOL Constantvhook(struct Varhookdata *h);
 
-   // Hook call functions
+   /* Hook call functions */
 extern BOOL Callvhook(struct Variable *var,struct Jcontext *jc,short code,struct Value *val);
 extern BOOL Callohook(struct Jobject *jo,struct Jcontext *jc,short code,UBYTE *name);
 
-   // Garbage collector
+   /* Garbage collector */
 extern void Keepobject(struct Jobject *jo,BOOL used);
 extern void Garbagecollect(struct Jcontext *jc);
 
@@ -146,65 +146,65 @@ extern void Dumpobjects(struct Jcontext *jc);
 
 extern void Initdate(struct Jcontext *jc);
 
-   // Get the current time in milliseconds
+   /* Get the current time in milliseconds */
 extern double Today(void);
 
 /*-----------------------------------------------------------------------*/
 /*-- jdebug -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Start, stop the debugger
+   /* Start, stop the debugger */
 extern void Startdebugger(struct Jcontext *jc);
 extern void Stopdebugger(struct Jcontext *jc);
 
-   // Debug halt
+   /* Debug halt */
 extern void Setdebugger(struct Jcontext *jc,struct Element *elt);
 
 /*-----------------------------------------------------------------------*/
 /*-- jexe ---------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Jexecute a program
+   /* Jexecute a program */
 extern void Jexecute(struct Jcontext *jc,struct Jobject *jthis,struct Jobject **gwtab);
 
-   // Create a function object for this internal function.
-   // Varargs are argument names (UBYTE *) terminated by NULL.
+   /* Create a function object for this internal function. */
+   /* Varargs are argument names (UBYTE *) terminated by NULL. */
 extern struct Jobject *Internalfunction(struct Jcontext *jc,UBYTE *name,
    void (*code)(void *),...);
 extern struct Jobject *InternalfunctionA(struct Jcontext *jc,UBYTE *name,
    void (*code)(void *),UBYTE **args);
 
-   // Adds a function object to global variable list
+   /* Adds a function object to global variable list */
 extern void Addglobalfunction(struct Jcontext *jc,struct Jobject *f);
 
-   // Adds a function object to an object's properties
+   /* Adds a function object to an object's properties */
 extern struct Variable *Addinternalproperty(struct Jcontext *jc,
    struct Jobject *jo,struct Jobject *f);
 
-   // Adds the .prototype property to a function object
+   /* Adds the .prototype property to a function object */
 extern void Addprototype(struct Jcontext *jc,struct Jobject *jo);
 
-   // Add a function object to the object's prototype
+   /* Add a function object to the object's prototype */
 extern void Addtoprototype(struct Jcontext *jc,struct Jobject *jo,struct Jobject *f);
 
-   // Call this function without parameters with this object as "this"
+   /* Call this function without parameters with this object as "this" */
 extern void Callfunctionbody(struct Jcontext *jc,struct Elementfunc *func,
    struct Jobject *jthis);
 
-   // Call this function with supplied arguments (must be struct Value *, NULL terminated)
+   /* Call this function with supplied arguments (must be struct Value *, NULL terminated) */
 extern void Callfunctionargs(struct Jcontext *jc,struct Elementfunc *func,
    struct Jobject *jthis,...);
 
-   // Add .constructor, default .toString() and .prototype properties
+   /* Add .constructor, default .toString() and .prototype properties */
 extern void Initconstruct(struct Jcontext *jc,struct Jobject *jo,struct Jobject *fo);
 
-   // Evaluate this string
+   /* Evaluate this string */
 extern void Jeval(struct Jcontext *jc,UBYTE *s);
 
-   // Expand a Jcontext with run-time context
+   /* Expand a Jcontext with run-time context */
 extern BOOL Newexecute(struct Jcontext *jc);
 
-   // Free run-time context
+   /* Free run-time context */
 extern void Freeexecute(struct Jcontext *jc);
 
 /*-----------------------------------------------------------------------*/
@@ -223,36 +223,36 @@ extern void Initmath(struct Jcontext *jc);
 /*-- jparse -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Extract the next token
+   /* Extract the next token */
 extern struct Token *Nexttoken(struct Parser *pa);
 
-   // Create a new parser
+   /* Create a new parser */
 extern void *Newparser(struct Jcontext *jc,UBYTE *source);
 extern void Freeparser(void *parser);
 
-   // Report error message. Total msg length must not exceed 127 characters.
+   /* Report error message. Total msg length must not exceed 127 characters. */
 extern void Errormsg(struct Parser *pa,UBYTE *msg,...);
 
-   // Return name of token
+   /* Return name of token */
 extern UBYTE *Tokenname(USHORT id);
 
-   // Get state ID, compare to see if parser has advanced.
+   /* Get state ID, compare to see if parser has advanced. */
 extern ULONG Parserstate(struct Parser *pa);
 
-   // Get current line number
+   /* Get current line number */
 extern long Plinenr(struct Parser *pa);
 
 /*-----------------------------------------------------------------------*/
 /*-- memory -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // allocate in private pool. If pool==NULL, allocate unpooled
+   /* allocate in private pool. If pool==NULL, allocate unpooled */
 extern void *Pallocmem(long size,ULONG flags,void *pool);
 
-   // free memory, works for all pools and unpooled memory
+   /* free memory, works for all pools and unpooled memory */
 extern void Freemem(void *mem);
 
-   // get the pool used for a given memory block
+   /* get the pool used for a given memory block */
 extern void *Getpool(void *p);
 
 /*-----------------------------------------------------------------------*/
@@ -261,7 +261,7 @@ extern void *Getpool(void *p);
 
 extern void Initnumber(struct Jcontext *jc);
 
-   // Create a new Number object, Useobject() it once.
+   /* Create a new Number object, Useobject() it once. */
 extern struct Jobject *Newnumber(struct Jcontext *jc,UBYTE attr,double nvalue);
 
 /*-----------------------------------------------------------------------*/
@@ -276,7 +276,7 @@ extern void Initobject(struct Jcontext *jc);
 
 extern void Initstring(struct Jcontext *jc);
 
-   // Create a new String object, Useobject() it once.
+   /* Create a new String object, Useobject() it once. */
 extern struct Jobject *Newstring(struct Jcontext *jc,UBYTE *svalue);
 
 /*-----------------------------------------------------------------------*/

--- a/Source/AWebAPL/keyfile.h
+++ b/Source/AWebAPL/keyfile.h
@@ -30,15 +30,15 @@
 /*-----------------------------------------------------------------------*/
 
                            /* Select type of release: */
-// #define BETAKEYFILE        /* Beta testers version, needs aweb.betakey */     
-// #define DEMOVERSION        /* Demo version, no key but limited features */
+/* #define BETAKEYFILE        /* Beta testers version, needs aweb.betakey */      */
+/* #define DEMOVERSION        /* Demo version, no key but limited features */ */
 #define COMMERCIAL         /* Commercial version, no key */
-// #define OSVERSION          /* Special Edition; implies DEMOVERSION, NETDEMO, NEED35 */
+/* #define OSVERSION          /* Special Edition; implies DEMOVERSION, NETDEMO, NEED35 */ */
 
-// #define DEVELOPER       /* no initial about requester */
-// #define LOCALONLY       /* no network access */
-// #define LIMITED         /* limited version. Use /support/LimitDemo to insert string */
-// #define NEED35          /* needs OS 3.5 or higher */
+/* #define DEVELOPER       /* no initial about requester */ */
+/* #define LOCALONLY       /* no network access */ */
+/* #define LIMITED         /* limited version. Use /support/LimitDemo to insert string */ */
+/* #define NEED35          /* needs OS 3.5 or higher */ */
 
 /* Set these to the correct values when you create your own browser */
 #define EMAILADDRESS "aweb@amigazen.com"
@@ -47,18 +47,18 @@
 /*-----------------------------------------------------------------------*/
 /* Special settings, normally not set here */
 
-// #define POPABOUT        /* is default for BETAVERSION unless DEVELOPER */
-// #define NOKEYFILE       /* set if DEMOVERSION or COMMERCIAL. Don't set here */
+/* #define POPABOUT        /* is default for BETAVERSION unless DEVELOPER */ */
+/* #define NOKEYFILE       /* set if DEMOVERSION or COMMERCIAL. Don't set here */ */
 
-// #define DEFAULTCFG      /* Path in ENV[ARC]: for default config */
+/* #define DEFAULTCFG      /* Path in ENV[ARC]: for default config */ */
 
-// #define LOCALDEMO       /* local-only no-net demo */
-// #define NETDEMO         /* network capable demo */
-// #define NOAREXXPORTS    /* no ARexx ports */
+/* #define LOCALDEMO       /* local-only no-net demo */ */
+/* #define NETDEMO         /* network capable demo */ */
+/* #define NOAREXXPORTS    /* no ARexx ports */ */
 
-// #define AWEBLIBVERSION  /* numeric library version */
-// #define AWEBLIBREVISION /* numeric library revision */
-// #define AWEBLIBVSTRING  /* library version string */
+/* #define AWEBLIBVERSION  /* numeric library version */ */
+/* #define AWEBLIBREVISION /* numeric library revision */ */
+/* #define AWEBLIBVSTRING  /* library version string */ */
 
 /*-----------------------------------------------------------------------*/
 


### PR DESCRIPTION
Replaces // comments with /* ... */ in several header files to keep the code C89-compatible.

No functional changes; comment-only cleanup for broader compiler compatibility (SAS/C, vbcc, GCC).