### PR TITLE
C89: replace C++-style comments in .c

### DIFF
--- a/Source/AWebAPL/Include/ezlists.h
+++ b/Source/AWebAPL/Include/ezlists.h
@@ -16,7 +16,7 @@
  *
  **********************************************************************/
 
-// easy lists
+/* easy lists */
 
 #ifndef EZLISTS_H
 #define EZLISTS_H

--- a/Source/AWebAPL/application.c
+++ b/Source/AWebAPL/application.c
@@ -1247,16 +1247,16 @@ static struct Application *Newapplication(struct Amset *ams)
          POINTERA_WordWidth,1,
          POINTERA_XOffset,-resizehorhot[0],
          POINTERA_YOffset,-resizehorhot[1],
-//         POINTERA_XResolution,POINTERXRESN_SCREENRES,
-//         POINTERA_YResolution,POINTERYRESN_SCREENRESASPECT,
+/*         POINTERA_XResolution,POINTERXRESN_SCREENRES, */
+/*         POINTERA_YResolution,POINTERYRESN_SCREENRESASPECT, */
          TAG_END);
       app->resizevertobj=NewObject(NULL,"pointerclass",
          POINTERA_BitMap,&resizevertbmap,
          POINTERA_WordWidth,1,
          POINTERA_XOffset,-resizeverthot[0],
          POINTERA_YOffset,-resizeverthot[1],
-//         POINTERA_XResolution,POINTERXRESN_SCREENRES,
-//         POINTERA_YResolution,POINTERYRESN_SCREENRESASPECT,
+/*         POINTERA_XResolution,POINTERXRESN_SCREENRES, */
+/*         POINTERA_YResolution,POINTERYRESN_SCREENRESASPECT, */
          TAG_END);
       app->handobj=NewObject(NULL,"pointerclass",
          POINTERA_BitMap,&handbmap,

--- a/Source/AWebAPL/awebcfg.c
+++ b/Source/AWebAPL/awebcfg.c
@@ -23,12 +23,12 @@
 __near long __stack=8192;
 const char *stack_cookie = "$STACK: 8192";
 
-// Library base pointers - only declare those that don't have proto headers
-// Note: gradientslider.gadget doesn't have a proto file in the Amiga NDK
-// IntuitionBase, LocaleBase, GfxBase are provided by proto headers
+/* Library base pointers - only declare those that don't have proto headers */
+/* Note: gradientslider.gadget doesn't have a proto file in the Amiga NDK */
+/* IntuitionBase, LocaleBase, GfxBase are provided by proto headers */
 struct Library *IconBase,*GadToolsBase,*AslBase,*ColorWheelBase,*GradientSliderBase;
 
-// Class library base pointers - these are provided by proto headers
+/* Class library base pointers - these are provided by proto headers */
 struct ClassLibrary *WindowBase,*LayoutBase,*ButtonBase,
    *ListBrowserBase,*ChooserBase,*IntegerBase,*SpaceBase,*CheckBoxBase,
    *StringBase,*LabelBase,*PaletteBase,*GlyphBase,*ClickTabBase;
@@ -319,7 +319,7 @@ void Makeclicktablist(struct List *list,UBYTE **labels)
    {  if(node=AllocClickTabNode(
          TNA_Text,labels[i],
          TNA_Number,i,
-//         TNA_Enabled,TRUE,
+/*         TNA_Enabled,TRUE, */
          TNA_Spacing,4,
          TAG_END))
          AddTail(list,node);

--- a/Source/AWebAPL/awebjs.c
+++ b/Source/AWebAPL/awebjs.c
@@ -36,7 +36,7 @@ char version[]="\0$VER:AWebJS " AWEBVERSION " " __AMIGADATE__;
 __near long __stack=16348;
 
 static void *AWebJSBase;
-// Library base pointers are now provided by proto headers
+/* Library base pointers are now provided by proto headers */
 
 /* Standard I/O */
 static __saveds __asm void aWrite(register __a0 struct Jcontext *jc)

--- a/Source/AWebAPL/awebjs.h
+++ b/Source/AWebAPL/awebjs.h
@@ -36,10 +36,10 @@
 #include <pragmas/exec_pragmas.h>
 #include <pragmas/locale_pragmas.h>
 
-// #define JSDEBUG
-// #define JSADDRESS
+/* #define JSDEBUG */
+/* #define JSADDRESS */
 
-// #define debug KPrintF
+/* #define debug KPrintF */
 #define debug / ## /KPrintF
 
 #define STRNIEQUAL(a,b,n)  !strnicmp(a,b,n)

--- a/Source/AWebAPL/body.c
+++ b/Source/AWebAPL/body.c
@@ -260,7 +260,7 @@ static BOOL Pushfont(struct Body *bd,short style,short size,struct Colorinfo *ci
       else if(fi->next->next)
       {  fi->face=fi->next->face;
       }
-//printf("pushfont color=%08x\n",fi->color);
+/*printf("pushfont color=%08x\n",fi->color); */
    }
    return (BOOL)(fi!=NULL);
 }
@@ -272,7 +272,7 @@ static void Popfont(struct Body *bd)
    {  REMOVE(fi);
       if(fi->facestring) FREE(fi->facestring);
       FREE(fi);
-//printf("popfont color=%08x\n",bd->bld->font.first->color);
+/*printf("popfont color=%08x\n",bd->bld->font.first->color); */
    }
 }
 

--- a/Source/AWebAPL/cabrtask.c
+++ b/Source/AWebAPL/cabrtask.c
@@ -288,7 +288,7 @@ static void Setpagegadgetattrs(struct Gadget *gad,void *page,struct Window *win,
 static void Editlbnode(struct Gadget *gad,struct Window *win,struct Requester *req,
    struct Node *node,...)
 {  if(DoGadgetMethod(gad,win,req,LBM_EDITNODE,NULL,node,VARARG(node)))
-   {  // RefreshGList(gad,win,req,1);
+   {  /* RefreshGList(gad,win,req,1); */
    }
 }
 

--- a/Source/AWebAPL/cfgbr.c
+++ b/Source/AWebAPL/cfgbr.c
@@ -1368,7 +1368,7 @@ BOOL Openbrowser(void)
             WA_SizeGadget,TRUE,
             WA_Activate,TRUE,
             WA_IDCMP,IDCMP_RAWKEY|IDCMP_MENUPICK,
-//            WA_SimpleRefresh,TRUE,
+/*            WA_SimpleRefresh,TRUE, */
             WA_PubScreen,pubscreen,
             setprefs.brww?TAG_IGNORE:WINDOW_Position,WPOS_CENTERSCREEN,
             WINDOW_Layout,toplayout=VLayoutObject,
@@ -1391,7 +1391,7 @@ BOOL Openbrowser(void)
                      PAGE_Add,Makemimepage(),
                   EndMember,
                EndMember,
-               //--------------------------------- Save, Use, Cancel
+               /*--------------------------------- Save, Use, Cancel */
                StartMember,HLayoutObject,
                   LAYOUT_BevelStyle,BVS_SBAR_VERT,
                   LAYOUT_SpaceOuter,TRUE,

--- a/Source/AWebAPL/cfgnw.c
+++ b/Source/AWebAPL/cfgnw.c
@@ -1928,7 +1928,7 @@ BOOL Opennetwork(void)
                      PAGE_Add,Makemailpage(),
                   EndMember,
                EndMember,
-               //--------------------------------- Save, Use, Cancel
+               /*--------------------------------- Save, Use, Cancel */
                StartMember,HLayoutObject,
                   LAYOUT_BevelStyle,BVS_SBAR_VERT,
                   LAYOUT_SpaceOuter,TRUE,

--- a/Source/AWebAPL/cfgpr.c
+++ b/Source/AWebAPL/cfgpr.c
@@ -838,7 +838,7 @@ BOOL Openprogram(void)
                      PAGE_Add,Makeprogramspage(),
                   EndMember,
                EndMember,
-               //--------------------------------- Save, Use, Cancel
+               /*--------------------------------- Save, Use, Cancel */
                StartMember,HLayoutObject,
                   LAYOUT_BevelStyle,BVS_SBAR_VERT,
                   LAYOUT_SpaceOuter,TRUE,

--- a/Source/AWebAPL/cfgui.c
+++ b/Source/AWebAPL/cfgui.c
@@ -1826,7 +1826,7 @@ BOOL Opengui(void)
                      PAGE_Add,Makenavspage(),
                   EndMember,
                EndMember,
-               //--------------------------------- Save, Use, Cancel
+               /*--------------------------------- Save, Use, Cancel */
                StartMember,HLayoutObject,
                   LAYOUT_BevelStyle,BVS_SBAR_VERT,
                   LAYOUT_SpaceOuter,TRUE,

--- a/Source/AWebAPL/element.c
+++ b/Source/AWebAPL/element.c
@@ -199,7 +199,7 @@ static long Getelement(struct Element *elt,struct Amset *ams)
 static long Measureelement(struct Element *elt,struct Ammeasure *amm)
 {  if(amm->ammr)
    {  amm->ammr->width=elt->aow;
-//      if(elt->eltflags&ELTF_NOBR)
+/*      if(elt->eltflags&ELTF_NOBR) */
       if(elt->eltflags&(ELTF_NOBR|ELTF_PREFORMAT))
       {  amm->ammr->minwidth=amm->addwidth+elt->aow;
          amm->ammr->addwidth=amm->ammr->minwidth;

--- a/Source/AWebAPL/file.c
+++ b/Source/AWebAPL/file.c
@@ -244,7 +244,7 @@ printf("fh=%x\n",fil->fh);
       else
       {  fil->fh=Open(fil->name,MODE_NEWFILE);
          if(fil->fh) Close(fil->fh);
-         fil->fh=Open(fil->name,MODE_OLDFILE);  // Open in shared mode
+         fil->fh=Open(fil->name,MODE_OLDFILE);  /* Open in shared mode */
       }
       SetVBuf(fil->fh,NULL,BUF_FULL,2048);
       fil->flags&=~FILF_NEW;

--- a/Source/AWebAPL/frame.c
+++ b/Source/AWebAPL/frame.c
@@ -704,7 +704,7 @@ static void Updatecopy(struct Frame *fr,BOOL changed)
 {  UBYTE *fragment=NULL;
    long y=-1,left=fr->left,top=fr->top;
    BOOL moved;
-//printf("Updatecopy %08x\n",fr);
+/*printf("Updatecopy %08x\n",fr); */
    /* Don't attempt to layout when we are iconified. */
    if(!fr->win) return;
    if(changed)
@@ -960,7 +960,7 @@ static void Setnewwinhis(struct Frame *fr,void *whis,BOOL noreferer)
 /* Frame has been resized */
 static void Resizeframe(struct Frame *fr,long newaow,long newaoh)
 {  BOOL neww=(newaow!=fr->aow),newh=(newaoh!=fr->aoh);
-//printf("Resizeframe %08x w:%d->%d h:%d->%d\n",fr,fr->aow,newaow,fr->aoh,newaoh);
+/*printf("Resizeframe %08x w:%d->%d h:%d->%d\n",fr,fr->aow,newaow,fr->aoh,newaoh); */
    Busypointer(TRUE);
    fr->aow=newaow;
    fr->aoh=newaoh;
@@ -1895,7 +1895,7 @@ static long Layoutframe(struct Frame *fr,struct Amlayout *aml)
          if(fr->flags&FRMF_PIXELHEIGHT) newaoh=fr->height;
          else newaoh=fr->height*aml->height/100;
          if(newaoh<minh) newaoh=minh;
-//printf("Layoutframe %08x\n",fr);
+/*printf("Layoutframe %08x\n",fr); */
          fr->aox=aml->startx;
          fr->aoy=0;  /* For frameset compatibility */
          if(fr->aox+newaow>aml->width && !(aml->flags&AMLF_FORCE))

--- a/Source/AWebAPL/framejs.c
+++ b/Source/AWebAPL/framejs.c
@@ -299,7 +299,7 @@ static void Methodopen(struct Jcontext *jc)
          Jasgobject(jc,NULL,nfr->jobject);
       }
       else if(nobanners)
-      {  // Don't show errors resulting from this function failing
+      {  /* Don't show errors resulting from this function failing */
          Jerrors(jc,prefs.jserrors,JERRORS_OFF,prefs.jswatch);
       }
       else if(njo=Jopenwindow(jc,fr->jobject,urlname,name,spec,fr->win))
@@ -1135,7 +1135,7 @@ BOOL Runjavascriptwith(struct Frame *fr,UBYTE *script,struct Jobject **jthisp,
 #ifndef DEMOVERSION
          Jdebug(jc,Agetattr(fr->win,AOWIN_Jsdebug));
 #endif
-// Jdumpobjects(jc);
+/* Jdumpobjects(jc); */
          result=Runjprogram(jc,fr->jobject,script,jthis,jgscope,fr->jprotect,(ULONG)fr);
          timer(clock);
          if(clock[0]>garbagetime)

--- a/Source/AWebAPL/frameset.c
+++ b/Source/AWebAPL/frameset.c
@@ -119,7 +119,7 @@ static void Parsespec(struct Frameset *frs,UBYTE *spec)
       }
       if(*p) p++;
    }
-// if(nrc>1) frs->flags|=FRSF_SENSIBLE;
+/* if(nrc>1) frs->flags|=FRSF_SENSIBLE; */
    if(nrc>0) frs->flags|=FRSF_SENSIBLE;
 }
 

--- a/Source/AWebAPL/haiku.h
+++ b/Source/AWebAPL/haiku.h
@@ -19,90 +19,90 @@
 
 #ifndef DEMOVERSION
 
-//1: about req
+/*1: about req */
 #define HAIKU1 (UBYTE *)" \n \nA web suddenly,\nForty years meditation\nMinds awaken, free"
 
-//2: quit warning
+/*2: quit warning */
 #define HAIKU2 (UBYTE *)"Last window was closed.\nDo you want to quit AWeb?\nMake up your mind now."
 
-//3: EPART_NOLIB
+/*3: EPART_NOLIB */
 #define HAIKU3 (UBYTE *)"Oh, the World Wide Web<br>Is so near and yet so far<br>Without TCP."
 
-//4: EPART_NOHOST
+/*4: EPART_NOHOST */
 #define HAIKU4 (UBYTE *)"A host with this name<br>Might exist somewhere indeed,<br>But I can't find it."
 
-//5: EPART_NOCONNECT
+/*5: EPART_NOCONNECT */
 #define HAIKU5 (UBYTE *)"The Internet links<br>Countless computers but one:<br>This connection failed."
 
-//25: EPART_NOCONNECT_TIMEOUT
+/*25: EPART_NOCONNECT_TIMEOUT */
 #define HAIKU25 (UBYTE *)"Time passed slowly by,<br>Waiting for a connection,<br>But it never came."
 
-//26: EPART_NOCONNECT_REFUSED
+/*26: EPART_NOCONNECT_REFUSED */
 #define HAIKU26 (UBYTE *)"The server said no,<br>Refusing to let you in,<br>Connection denied."
 
-//27: EPART_NOCONNECT_RESET
+/*27: EPART_NOCONNECT_RESET */
 #define HAIKU27 (UBYTE *)"Connection was cut,<br>Reset by the other side,<br>Try again later."
 
-//28: EPART_NOCONNECT_UNREACH
+/*28: EPART_NOCONNECT_UNREACH */
 #define HAIKU28 (UBYTE *)"The network is far,<br>Unreachable from here now,<br>Check your connection."
 
-//29: EPART_NOCONNECT_HOSTUNREACH
+/*29: EPART_NOCONNECT_HOSTUNREACH */
 #define HAIKU29 (UBYTE *)"The host is distant,<br>No route can reach it from here,<br>Try another way."
 
-//6: EPART_NOFILE
+/*6: EPART_NOFILE */
 #define HAIKU6 (UBYTE *)"So big a hard disk,<br>But yet a file with this name<br>Is nowhere on it."
 
-//7: EPART_XAWEB
+/*7: EPART_XAWEB */
 #define HAIKU7 (UBYTE *)"X-aweb is fine,<br>But what followed it is not:<br>Please choose something else."
 
-//8: EPART_NOLOGIN
+/*8: EPART_NOLOGIN */
 #define HAIKU8 (UBYTE *)"Was it a typo<br>Or did you try something bad:<br>Login was denied."
 
-//9: EPART_NOPROGRAM:
+/*9: EPART_NOPROGRAM: */
 #define HAIKU9 (UBYTE *)"I'd like to obey<br>But I must know the program;<br>Without it won't go."
 
-//10: Unknown MIME type
+/*10: Unknown MIME type */
 #define HAIKU10 (UBYTE *)"Wonderful MIME type,\nBut what should I do with it:\nSave it or leave it?"
 
-//11: Can't make SSL connection
+/*11: Can't make SSL connection */
 #define HAIKU11 (UBYTE *)"SSL is nice,\nBut some sites don't support it;\nThis is one of them."
 
-//12: No SSL supported
+/*12: No SSL supported */
 #define HAIKU12 (UBYTE *)"Want security?\nThen you need the libraries,\nOr else it won't work."
 
-//13: Certificate not verified
+/*13: Certificate not verified */
 #define HAIKU13 (UBYTE *)"Nice certificate,\nBut I can't verify it\nSo who is this guy?"
 
-//14: EPART_NOAWEBLIB
+/*14: EPART_NOAWEBLIB */
 #define HAIKU14 (UBYTE *)"What the heck is wrong?<br>Did you mess with aweblibs,<br>There is one missing!"
 
-//15: EPART_ERRSCHEME
+/*15: EPART_ERRSCHEME */
 #define HAIKU15 (UBYTE *)"A rich fantasy!<br>Please restrict your URLs<br>To known address schemes"
 
-//16: Form unsecure warning
+/*16: Form unsecure warning */
 #define HAIKU16 (UBYTE *)"The things you typed here\nAre sent with no protection,\nUnless you cancel."
 
-//17: Del all images?
+/*17: Del all images? */
 #define HAIKU17 (UBYTE *)"Too many pictures\nFilling up the cache in vain\nSo they will be gone."
 
-//18: Del all documents?
+/*18: Del all documents? */
 #define HAIKU18 (UBYTE *)"Every document\nWill be gone from the cache\nWhen I am ready."
 
-//19: Del everything?
+/*19: Del everything? */
 #define HAIKU19 (UBYTE *)"Everything is void,\nEspecially the cached files,\nIf I continue."
 
-//20: Cleanup warning
+/*20: Cleanup warning */
 #define HAIKU20 (UBYTE *)"Cleaning up the cache\nWill delete all foreign files.\nShould I continue?"
 
-//21: Stop TCP too?
+/*21: Stop TCP too? */
 #define HAIKU21 (UBYTE *)"The TCP stack,\nCan't see any use for it,\nSo should I stop it?"
 
-//22: Incomplete file
+/*22: Incomplete file */
 #define HAIKU22 (UBYTE *)"File is incomplete:\nGot less bytes than expected.\nBeautiful bytes, though!"
 
-//23
+/*23 */
 
-//24: Can't close screen
+/*24: Can't close screen */
 #define HAIKU24 (UBYTE *)"Although I'd like to,\nI can't close the screen right now:\nWindows are open."
 
 #else

--- a/Source/AWebAPL/hotmanager.c
+++ b/Source/AWebAPL/hotmanager.c
@@ -133,11 +133,11 @@ static struct DrawList hidedata[]=
 
 /*-----------------------------------------------------------------------*/
 
-// Add prototypes for memory allocation if needed
+/* Add prototypes for memory allocation if needed */
 extern APTR Allocmem(ULONG size, ULONG flags);
 extern void Freemem(APTR mem);
 
-// Local static declarations to avoid header conflicts
+/* Local static declarations to avoid header conflicts */
 static struct Node *Getnode(struct List *list, long n);
 static void Freechooserlist(struct List *list);
 static void Makechooserlist(struct List *list, UBYTE **labels);

--- a/Source/AWebAPL/http.c
+++ b/Source/AWebAPL/http.c
@@ -122,7 +122,7 @@ static UBYTE *useragentspoof="User-Agent: %s; (Spoofed by Amiga-AWeb/3.6; AmigaO
 
 static UBYTE *fixedheaders=
    "Accept: */*;q=1\r\nAccept-Encoding: gzip\r\n";
-//   "Accept: text/html;level=3, text/html;version=3.0, */*;q=1\r\n";
+/*   "Accept: text/html;level=3, text/html;version=3.0, */*;q=1\r\n"; */
 
 /* HTTP/1.1 specific headers */
 static UBYTE *connection="Connection: close\r\n";
@@ -1519,8 +1519,8 @@ static BOOL Readdata(struct Httpinfo *hi)
       {  debug_printf("DEBUG: Readdata loop: Processing data block, length=%ld, flags=0x%04X, parttype='%s'\n", 
                 hi->blocklength, hi->flags, hi->parttype[0] ? (char *)hi->parttype : "(none)");
          
-         // first block of the encoded data
-         // allocate buffer and initialize zlib
+         /* first block of the encoded data */
+         /* allocate buffer and initialize zlib */
          if((hi->flags & HTTPIF_GZIPENCODED) && !(hi->flags & HTTPIF_GZIPDECODING))
          {  int i;
             UBYTE *p;
@@ -2374,7 +2374,7 @@ static BOOL Readdata(struct Httpinfo *hi)
                break;
             }
             
-            err=inflateInit2(&d_stream,16+15); // set zlib to expect 'gzip-header'
+            err=inflateInit2(&d_stream,16+15); /* set zlib to expect 'gzip-header' */
             if(err!=Z_OK) {
                debug_printf("DEBUG: zlib Init Fail: %d\n", err);
                if(gzipbuffer) FREE(gzipbuffer);
@@ -3782,7 +3782,7 @@ static BOOL Readdata(struct Httpinfo *hi)
             }
             hi->flags &= ~HTTPIF_GZIPENCODED;
             hi->flags &= ~HTTPIF_GZIPDECODING;
-            gzip_end=1; // Success break!
+            gzip_end=1; /* Success break! */
          }
          else if(err!=Z_OK)
          {  if(err==Z_DATA_ERROR) printf("zlib DATA ERROR - avail_in=%lu, avail_out=%lu\n", d_stream.avail_in, d_stream.avail_out);
@@ -4179,7 +4179,7 @@ static BOOL Readdata(struct Httpinfo *hi)
                } else {
                   debug_printf("DEBUG: End of gzip data stream\n");
                }
-               gzip_end=1; // Finished or Error
+               gzip_end=1; /* Finished or Error */
             }
             else
             {  d_stream.next_in=gzipbuffer;

--- a/Source/AWebAPL/imgsource.c
+++ b/Source/AWebAPL/imgsource.c
@@ -104,7 +104,7 @@ static long Transparentgif(struct Imgprocess *imp)
                   break;
                }
                if(buf[0]==0x21)
-               {  pos+=2; // 3+buf[2];
+               {  pos+=2; /* 3+buf[2]; */
                   do
                   {  Seek(fh,pos,OFFSET_BEGINNING);
                      if(Read(fh,buf,1)!=1) buf[0]=0;

--- a/Source/AWebAPL/jdata.c
+++ b/Source/AWebAPL/jdata.c
@@ -337,7 +337,7 @@ struct Jobject *Newobject(struct Jcontext *jc)
       else
       {  ADDTAIL(&jc->objects,jo);
       }
-//debug(" NEW object %08lx\n",jo);
+/*debug(" NEW object %08lx\n",jo); */
    }
    return jo;
 }
@@ -355,7 +355,7 @@ void Disposeobject(struct Jobject *jo)
       if(jo->function)
       {  Jdispose(jo->function);
       }
-//debug ("FREE object %08lx\n",jo);
+/*debug ("FREE object %08lx\n",jo); */
       FREE(jo);
    }
 }

--- a/Source/AWebAPL/jmemory.c
+++ b/Source/AWebAPL/jmemory.c
@@ -58,7 +58,7 @@ void *Pallocmem(long size,ULONG flags,void *pool)
 {  void *mem;
    if(pool) mem=AllocPooled(pool,size+8);
    else mem=AllocMem(size+8,flags|MEMF_PUBLIC|MEMF_CLEAR);
-//Debugmem("ALLOC",mem,size,&pool);
+/*Debugmem("ALLOC",mem,size,&pool); */
    if(mem)
    {  *(void **)mem=pool;
       *(long *)((ULONG)mem+4)=size+8;
@@ -73,7 +73,7 @@ void Freemem(void *mem)
    if(mem)
    {  pool=*(void **)((ULONG)mem-8);
       size=*(long *)((ULONG)mem-4);
-//Debugmem("FREE ",(void *)((ULONG)mem-8),-(size-8),&mem);
+/*Debugmem("FREE ",(void *)((ULONG)mem-8),-(size-8),&mem); */
       if(pool) FreePooled(pool,(void *)((ULONG)mem-8),size);
       else FreeMem((void *)((ULONG)mem-8),size);
    }

--- a/Source/AWebAPL/jprotos.h
+++ b/Source/AWebAPL/jprotos.h
@@ -22,23 +22,23 @@
 /*-- jslib --------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Duplicate string
+   /* Duplicate string */
 extern UBYTE *Jdupstr(UBYTE *str,long len,void *pool);
 
-   // Dynamic buffer, text is kept null-terminated
+   /* Dynamic buffer, text is kept null-terminated */
 extern struct Jbuffer *Newjbuffer(void *pool);
 extern void Freejbuffer(struct Jbuffer *jb);
 extern void Addtojbuffer(struct Jbuffer *jb,UBYTE *text,long length);
 
-   // Show error. Returns true if all errors are to be ignored cq debugger wanted.
-   // Set pos to <0 to show a runtime error requester.
+   /* Show error. Returns true if all errors are to be ignored cq debugger wanted. */
+   /* Set pos to <0 to show a runtime error requester. */
 extern BOOL Errorrequester(struct Jcontext *jc,long lnr,UBYTE *line,
    long pos,UBYTE *msg,UBYTE **args);
 
-   // Call feedback. Returns TRUE if continue, FALSE if break.
+   /* Call feedback. Returns TRUE if continue, FALSE if break. */
 extern BOOL Feedback(struct Jcontext *jc);
 
-   // Return TRUE if caller owns the active window
+   /* Return TRUE if caller owns the active window */
 extern BOOL Calleractive(void);
 
 /*-----------------------------------------------------------------------*/
@@ -47,16 +47,16 @@ extern BOOL Calleractive(void);
 
 extern void Initarray(struct Jcontext *jc);
 
-   // Create a new empty Array object, Useobject() it once.
+   /* Create a new empty Array object, Useobject() it once. */
 extern struct Jobject *Newarray(struct Jcontext *jc);
 
-   // Find the nth array element, or NULL
+   /* Find the nth array element, or NULL */
 extern struct Variable *Arrayelt(struct Jobject *jo,long n);
 
-   // Add an element to this array
+   /* Add an element to this array */
 extern struct Variable *Addarrayelt(struct Jcontext *jc,struct Jobject *jo);
 
-   // Tests if this object is an array
+   /* Tests if this object is an array */
 extern BOOL Isarray(struct Jobject *jo);
 
 /*-----------------------------------------------------------------------*/
@@ -65,33 +65,33 @@ extern BOOL Isarray(struct Jobject *jo);
 
 extern void Initboolean(struct Jcontext *jc);
 
-   // Create a new Boolean object, Useobject() it once.
+   /* Create a new Boolean object, Useobject() it once. */
 extern struct Jobject *Newboolean(struct Jcontext *jc,BOOL bvalue);
 
 /*-----------------------------------------------------------------------*/
 /*-- jcomp --------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Compile the source and construct an element tree
+   /* Compile the source and construct an element tree */
 extern void Jcompile(struct Jcontext *jc,UBYTE *source);
 
-   // Compile this source and make it into a function object.
+   /* Compile this source and make it into a function object. */
 struct Jobject *Jcompiletofunction(struct Jcontext *jc,UBYTE *source,UBYTE *name);
 
-   // Decompile the source
+   /* Decompile the source */
 extern struct Jbuffer *Jdecompile(struct Jcontext *jc,struct Element *elt);
 
-   // Dispose this element
+   /* Dispose this element */
 extern void Jdispose(struct Element *elt);
 
 /*-----------------------------------------------------------------------*/
 /*-- jdata --------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Call this property function
+   /* Call this property function */
 extern BOOL Callproperty(struct Jcontext *jc,struct Jobject *jo,UBYTE *name);
 
-   // Value processing
+   /* Value processing */
 extern void Clearvalue(struct Value *v);
 extern void Asgvalue(struct Value *to,struct Value *from);
 extern void Asgnumber(struct Value *to,UBYTE attr,double n);
@@ -100,41 +100,41 @@ extern void Asgstring(struct Value *to,UBYTE *s,void *pool);
 extern void Asgobject(struct Value *to,struct Jobject *jo);
 extern void Asgfunction(struct Value *to,struct Jobject *f,struct Jobject *fthis);
 
-   // WARNING: Tostring() cannot be called for ex->val directly.
+   /* WARNING: Tostring() cannot be called for ex->val directly. */
 extern void Tostring(struct Value *v,struct Jcontext *jc);
 extern void Tonumber(struct Value *v,struct Jcontext *jc);
 extern void Toboolean(struct Value *v,struct Jcontext *jc);
 extern void Toobject(struct Value *v,struct Jcontext *jc);
 extern void Tofunction(struct Value *v,struct Jcontext *jc);
 
-   // Default toString property function
+   /* Default toString property function */
 extern void Defaulttostring(struct Jcontext *jc);
 
-   // Variables
+   /* Variables */
 extern struct Variable *Newvar(UBYTE *name,void *pool);
 extern void Disposevar(struct Variable *var);
 
-   // Objects
+   /* Objects */
 extern struct Jobject *Newobject(struct Jcontext *jc);
 extern void Disposeobject(struct Jobject *jo);
 extern void Clearobject(struct Jobject *jo,UBYTE **except);
 extern struct Variable *Addproperty(struct Jobject *jo,UBYTE *name);
 extern struct Variable *Findproperty(struct Jobject *jo,UBYTE *name);
 
-   // Objhook for .prototype
+   /* Objhook for .prototype */
 extern BOOL Prototypeohook(struct Objhookdata *h);
 
-   // Variable hook for .prototype properties
+   /* Variable hook for .prototype properties */
 extern BOOL Protopropvhook(struct Varhookdata *h);
 
-   // General hook function for constants (that cannot change their value)
+   /* General hook function for constants (that cannot change their value) */
 extern BOOL Constantvhook(struct Varhookdata *h);
 
-   // Hook call functions
+   /* Hook call functions */
 extern BOOL Callvhook(struct Variable *var,struct Jcontext *jc,short code,struct Value *val);
 extern BOOL Callohook(struct Jobject *jo,struct Jcontext *jc,short code,UBYTE *name);
 
-   // Garbage collector
+   /* Garbage collector */
 extern void Keepobject(struct Jobject *jo,BOOL used);
 extern void Garbagecollect(struct Jcontext *jc);
 
@@ -146,65 +146,65 @@ extern void Dumpobjects(struct Jcontext *jc);
 
 extern void Initdate(struct Jcontext *jc);
 
-   // Get the current time in milliseconds
+   /* Get the current time in milliseconds */
 extern double Today(void);
 
 /*-----------------------------------------------------------------------*/
 /*-- jdebug -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Start, stop the debugger
+   /* Start, stop the debugger */
 extern void Startdebugger(struct Jcontext *jc);
 extern void Stopdebugger(struct Jcontext *jc);
 
-   // Debug halt
+   /* Debug halt */
 extern void Setdebugger(struct Jcontext *jc,struct Element *elt);
 
 /*-----------------------------------------------------------------------*/
 /*-- jexe ---------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Jexecute a program
+   /* Jexecute a program */
 extern void Jexecute(struct Jcontext *jc,struct Jobject *jthis,struct Jobject **gwtab);
 
-   // Create a function object for this internal function.
-   // Varargs are argument names (UBYTE *) terminated by NULL.
+   /* Create a function object for this internal function. */
+   /* Varargs are argument names (UBYTE *) terminated by NULL. */
 extern struct Jobject *Internalfunction(struct Jcontext *jc,UBYTE *name,
    void (*code)(void *),...);
 extern struct Jobject *InternalfunctionA(struct Jcontext *jc,UBYTE *name,
    void (*code)(void *),UBYTE **args);
 
-   // Adds a function object to global variable list
+   /* Adds a function object to global variable list */
 extern void Addglobalfunction(struct Jcontext *jc,struct Jobject *f);
 
-   // Adds a function object to an object's properties
+   /* Adds a function object to an object's properties */
 extern struct Variable *Addinternalproperty(struct Jcontext *jc,
    struct Jobject *jo,struct Jobject *f);
 
-   // Adds the .prototype property to a function object
+   /* Adds the .prototype property to a function object */
 extern void Addprototype(struct Jcontext *jc,struct Jobject *jo);
 
-   // Add a function object to the object's prototype
+   /* Add a function object to the object's prototype */
 extern void Addtoprototype(struct Jcontext *jc,struct Jobject *jo,struct Jobject *f);
 
-   // Call this function without parameters with this object as "this"
+   /* Call this function without parameters with this object as "this" */
 extern void Callfunctionbody(struct Jcontext *jc,struct Elementfunc *func,
    struct Jobject *jthis);
 
-   // Call this function with supplied arguments (must be struct Value *, NULL terminated)
+   /* Call this function with supplied arguments (must be struct Value *, NULL terminated) */
 extern void Callfunctionargs(struct Jcontext *jc,struct Elementfunc *func,
    struct Jobject *jthis,...);
 
-   // Add .constructor, default .toString() and .prototype properties
+   /* Add .constructor, default .toString() and .prototype properties */
 extern void Initconstruct(struct Jcontext *jc,struct Jobject *jo,struct Jobject *fo);
 
-   // Evaluate this string
+   /* Evaluate this string */
 extern void Jeval(struct Jcontext *jc,UBYTE *s);
 
-   // Expand a Jcontext with run-time context
+   /* Expand a Jcontext with run-time context */
 extern BOOL Newexecute(struct Jcontext *jc);
 
-   // Free run-time context
+   /* Free run-time context */
 extern void Freeexecute(struct Jcontext *jc);
 
 /*-----------------------------------------------------------------------*/
@@ -223,36 +223,36 @@ extern void Initmath(struct Jcontext *jc);
 /*-- jparse -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // Extract the next token
+   /* Extract the next token */
 extern struct Token *Nexttoken(struct Parser *pa);
 
-   // Create a new parser
+   /* Create a new parser */
 extern void *Newparser(struct Jcontext *jc,UBYTE *source);
 extern void Freeparser(void *parser);
 
-   // Report error message. Total msg length must not exceed 127 characters.
+   /* Report error message. Total msg length must not exceed 127 characters. */
 extern void Errormsg(struct Parser *pa,UBYTE *msg,...);
 
-   // Return name of token
+   /* Return name of token */
 extern UBYTE *Tokenname(USHORT id);
 
-   // Get state ID, compare to see if parser has advanced.
+   /* Get state ID, compare to see if parser has advanced. */
 extern ULONG Parserstate(struct Parser *pa);
 
-   // Get current line number
+   /* Get current line number */
 extern long Plinenr(struct Parser *pa);
 
 /*-----------------------------------------------------------------------*/
 /*-- memory -------------------------------------------------------------*/
 /*-----------------------------------------------------------------------*/
 
-   // allocate in private pool. If pool==NULL, allocate unpooled
+   /* allocate in private pool. If pool==NULL, allocate unpooled */
 extern void *Pallocmem(long size,ULONG flags,void *pool);
 
-   // free memory, works for all pools and unpooled memory
+   /* free memory, works for all pools and unpooled memory */
 extern void Freemem(void *mem);
 
-   // get the pool used for a given memory block
+   /* get the pool used for a given memory block */
 extern void *Getpool(void *p);
 
 /*-----------------------------------------------------------------------*/
@@ -261,7 +261,7 @@ extern void *Getpool(void *p);
 
 extern void Initnumber(struct Jcontext *jc);
 
-   // Create a new Number object, Useobject() it once.
+   /* Create a new Number object, Useobject() it once. */
 extern struct Jobject *Newnumber(struct Jcontext *jc,UBYTE attr,double nvalue);
 
 /*-----------------------------------------------------------------------*/
@@ -276,7 +276,7 @@ extern void Initobject(struct Jcontext *jc);
 
 extern void Initstring(struct Jcontext *jc);
 
-   // Create a new String object, Useobject() it once.
+   /* Create a new String object, Useobject() it once. */
 extern struct Jobject *Newstring(struct Jcontext *jc,UBYTE *svalue);
 
 /*-----------------------------------------------------------------------*/

--- a/Source/AWebAPL/keyfile.h
+++ b/Source/AWebAPL/keyfile.h
@@ -30,15 +30,15 @@
 /*-----------------------------------------------------------------------*/
 
                            /* Select type of release: */
-// #define BETAKEYFILE        /* Beta testers version, needs aweb.betakey */     
-// #define DEMOVERSION        /* Demo version, no key but limited features */
+/* #define BETAKEYFILE        /* Beta testers version, needs aweb.betakey */      */
+/* #define DEMOVERSION        /* Demo version, no key but limited features */ */
 #define COMMERCIAL         /* Commercial version, no key */
-// #define OSVERSION          /* Special Edition; implies DEMOVERSION, NETDEMO, NEED35 */
+/* #define OSVERSION          /* Special Edition; implies DEMOVERSION, NETDEMO, NEED35 */ */
 
-// #define DEVELOPER       /* no initial about requester */
-// #define LOCALONLY       /* no network access */
-// #define LIMITED         /* limited version. Use /support/LimitDemo to insert string */
-// #define NEED35          /* needs OS 3.5 or higher */
+/* #define DEVELOPER       /* no initial about requester */ */
+/* #define LOCALONLY       /* no network access */ */
+/* #define LIMITED         /* limited version. Use /support/LimitDemo to insert string */ */
+/* #define NEED35          /* needs OS 3.5 or higher */ */
 
 /* Set these to the correct values when you create your own browser */
 #define EMAILADDRESS "aweb@amigazen.com"
@@ -47,18 +47,18 @@
 /*-----------------------------------------------------------------------*/
 /* Special settings, normally not set here */
 
-// #define POPABOUT        /* is default for BETAVERSION unless DEVELOPER */
-// #define NOKEYFILE       /* set if DEMOVERSION or COMMERCIAL. Don't set here */
+/* #define POPABOUT        /* is default for BETAVERSION unless DEVELOPER */ */
+/* #define NOKEYFILE       /* set if DEMOVERSION or COMMERCIAL. Don't set here */ */
 
-// #define DEFAULTCFG      /* Path in ENV[ARC]: for default config */
+/* #define DEFAULTCFG      /* Path in ENV[ARC]: for default config */ */
 
-// #define LOCALDEMO       /* local-only no-net demo */
-// #define NETDEMO         /* network capable demo */
-// #define NOAREXXPORTS    /* no ARexx ports */
+/* #define LOCALDEMO       /* local-only no-net demo */ */
+/* #define NETDEMO         /* network capable demo */ */
+/* #define NOAREXXPORTS    /* no ARexx ports */ */
 
-// #define AWEBLIBVERSION  /* numeric library version */
-// #define AWEBLIBREVISION /* numeric library revision */
-// #define AWEBLIBVSTRING  /* library version string */
+/* #define AWEBLIBVERSION  /* numeric library version */ */
+/* #define AWEBLIBREVISION /* numeric library revision */ */
+/* #define AWEBLIBVSTRING  /* library version string */ */
 
 /*-----------------------------------------------------------------------*/
 

--- a/Source/AWebAPL/makeindex.c
+++ b/Source/AWebAPL/makeindex.c
@@ -37,7 +37,7 @@
 #define ALLOCSTRUCT(s,n,f) ALLOCTYPE(struct s,n,f)
 #define FREE(p)            FreeVec(p)
 
-// Library base pointers are now provided by proto headers
+/* Library base pointers are now provided by proto headers */
 
 static void Writeindex(UBYTE t,UBYTE *line,long to)
 {  UBYTE buf[512];

--- a/Source/AWebAPL/object.c
+++ b/Source/AWebAPL/object.c
@@ -312,7 +312,7 @@ static ULONG Dispatch(struct Aobject *ao,struct Amessage *amsg)
    return result;
 }
 
-// Emergency dispatcher in case of stack overflow
+/* Emergency dispatcher in case of stack overflow */
 static ULONG Emergencydisp(struct Amessage *amsg)
 {  switch(amsg->method)
    {  case AOM_LAYOUT:

--- a/Source/AWebAPL/printlib.c
+++ b/Source/AWebAPL/printlib.c
@@ -28,7 +28,7 @@
 #include <proto/intuition.h>
 
 static void *AwebPluginBase;
-// Library base pointers are now provided by proto headers
+/* Library base pointers are now provided by proto headers */
 
 /*-----------------------------------------------------------------------*/
 /* AWebLib module startup */

--- a/Source/AWebAPL/task.c
+++ b/Source/AWebAPL/task.c
@@ -121,7 +121,7 @@ static void __saveds Subtask(void)
       task->state=TSKS_DEAD;
       ReleaseSemaphore(&task->sema);
       DeleteMsgPort(port);
-//KPrintF("%08lx - Subtask ends\n",task);
+/*KPrintF("%08lx - Subtask ends\n",task); */
    }
    else
    {  task->state=TSKS_DEAD;
@@ -135,9 +135,9 @@ ULONG Waittask(ULONG signals)
    struct Atask *task=FindTask(NULL)->tc_UserData;
    if(!task->subport->lh_Head->ln_Succ)
    {  
-//KPrintF("%08lx - Wait for %08lx\n",task,signals);
+/*KPrintF("%08lx - Wait for %08lx\n",task,signals); */
       got=Wait(signals|(1<<task->subport->mp_SigBit)|SIGBREAKF_CTRL_C);
-//KPrintF("%08lx - Wait for %08lx got %08lx\n",task,signals,got);
+/*KPrintF("%08lx - Wait for %08lx got %08lx\n",task,signals,got); */
       if(got&SIGBREAKF_CTRL_C)
       {  /* Reset Ctrl-C flag after Wait() has cleared it... */
          SetSignal(SIGBREAKF_CTRL_C,SIGBREAKF_CTRL_C);
@@ -221,7 +221,7 @@ BOOL Obtaintasksemaphore(struct SignalSemaphore *sema)
    struct MsgPort *port=CreateMsgPort();
    if(port)
    {  smsg.mn_ReplyPort=port;
-//KPrintF("%08lx - Obtaintasksemaphore %08lx\n",FindTask(NULL)->tc_UserData,sema);
+/*KPrintF("%08lx - Obtaintasksemaphore %08lx\n",FindTask(NULL)->tc_UserData,sema); */
       Procure(sema,&smsg);
       for(;;)
       {  /* If break signal received, cancel the semaphore request. The message
@@ -229,7 +229,7 @@ BOOL Obtaintasksemaphore(struct SignalSemaphore *sema)
           * Reset the break signal if it was cleared by Wait(). */
          if(mask&SIGBREAKF_CTRL_C)
          {  Vacate(sema,&smsg);
-//KPrintF("%08lx - Obtaintasksemaphore %08lx got Ctrl-C\n",FindTask(NULL)->tc_UserData,sema);
+/*KPrintF("%08lx - Obtaintasksemaphore %08lx got Ctrl-C\n",FindTask(NULL)->tc_UserData,sema); */
             SetSignal(SIGBREAKF_CTRL_C,SIGBREAKF_CTRL_C);
          }
          /* See if our message has replied yet. If so, break the wait loop. */
@@ -239,7 +239,7 @@ BOOL Obtaintasksemaphore(struct SignalSemaphore *sema)
       }
    }
    if(port) DeleteMsgPort(port);
-//KPrintF("%08lx - Obtaintasksemaphore %08lx continue\n",FindTask(NULL)->tc_UserData,sema);
+/*KPrintF("%08lx - Obtaintasksemaphore %08lx continue\n",FindTask(NULL)->tc_UserData,sema); */
    return BOOLVAL(smsg.ssm_Semaphore);
 }
 
@@ -272,11 +272,11 @@ long Updatetask(struct Amessage *amsg)
          atm->task=task;
          atm->flags=TSMF_UPDATE;
          ObtainSemaphore(&portsema);
-//KPrintF("%08lx - Updatetask msg=%08lx\n",task,atm);
+/*KPrintF("%08lx - Updatetask msg=%08lx\n",task,atm); */
          PutMsg(taskport,atm);
          ReleaseSemaphore(&portsema);
          WaitPort(task->updport);
-//KPrintF("%08lx - Continues  msg=%08lx\n",task,atm);
+/*KPrintF("%08lx - Continues  msg=%08lx\n",task,atm); */
          atm=(struct Ataskmsg *)GetMsg(task->updport);
          result=atm->result;
          FREE(atm);
@@ -303,13 +303,13 @@ long UpdatetaskattrsA(struct TagItem *tags)
          atm->task=task;
          atm->flags=TSMF_UPDATE|TSMF_UPDATEATTRS;
          if(async) atm->flags|=TSMF_ASYNC;
-//KPrintF("%08lx - Updatetaskattrs msg=%08lx async=%d\n",task,atm,async);
+/*KPrintF("%08lx - Updatetaskattrs msg=%08lx async=%d\n",task,atm,async); */
          ObtainSemaphore(&portsema);
          PutMsg(taskport,atm);
          ReleaseSemaphore(&portsema);
          if(!async)
          {  WaitPort(task->updport);
-//KPrintF("%08lx - Continues  msg=%08lx\n",task,atm);
+/*KPrintF("%08lx - Continues  msg=%08lx\n",task,atm); */
             atm=(struct Ataskmsg *)GetMsg(task->updport);
             result=atm->result;
             FREE(atm);
@@ -340,7 +340,7 @@ static void Processreply(struct Ataskmsg *atm)
 {  struct Atask *task;
    if(atm)
    {  task=atm->task;
-//KPrintF("%08lx * Processreply msg=%08lx\n",task,atm);
+/*KPrintF("%08lx * Processreply msg=%08lx\n",task,atm); */
       if(atm->flags&TSMF_UPDATE)
       {  if(task->target)
          {  task->flags|=TSKF_PROCESSING;
@@ -363,7 +363,7 @@ static void Processreply(struct Ataskmsg *atm)
          }
          else
          {  
-//KPrintF("%08lx * Replied      msg=%08lx\n",task,atm);
+/*KPrintF("%08lx * Replied      msg=%08lx\n",task,atm); */
             ReplyMsg(atm);
          }
       }
@@ -474,11 +474,11 @@ static void Starttask(struct Atask *task)
 static void Stoptask(struct Atask *task,BOOL async)
 {  struct SemaphoreMessage smsg={0},*msg;
    ULONG mask;
-//KPrintF("%08lx * Stoptask\n",task);
+/*KPrintF("%08lx * Stoptask\n",task); */
    ObtainSemaphore(&task->sema);
    if(task->state!=TSKS_DEAD && task->state!=TSKS_NEW)
    {  
-//KPrintF("%08lx * Stoptask Signal Ctrl-C\n",task);
+/*KPrintF("%08lx * Stoptask Signal Ctrl-C\n",task); */
       Signal(task->proc,SIGBREAKF_CTRL_C);
    }
    ReleaseSemaphore(&task->sema);
@@ -491,8 +491,8 @@ static void Stoptask(struct Atask *task,BOOL async)
       Procure(&task->runsema,&smsg);
       for(;;)
       {  mask=Wait((1<<taskport->mp_SigBit)|(1<<semaport->mp_SigBit));
-//KPrintF("%08lx * Stoptask mask=%08lx (taskport=%08lx semaport=%08lx)\n",task,mask,
-//1<<taskport->mp_SigBit,1<<semaport->mp_SigBit);
+/*KPrintF("%08lx * Stoptask mask=%08lx (taskport=%08lx semaport=%08lx)\n",task,mask, */
+/*1<<taskport->mp_SigBit,1<<semaport->mp_SigBit); */
          if(mask&(1<<semaport->mp_SigBit))
          {  if((msg=(struct SemaphoreMessage *)GetMsg(semaport))
             && msg->ssm_Semaphore==&task->runsema)

--- a/Source/AWebAPL/textarea.c
+++ b/Source/AWebAPL/textarea.c
@@ -588,7 +588,7 @@ static long Handlekeytext(struct Textarea *txa,struct Coords *coo,
             }
             else if(buffer[0]==0x19)  /* Ctrl-Y */
             {  long start,length;
-//Unclipcoords(coo);coo=NULL; /* Prevent CPR lockup */
+/*Unclipcoords(coo);coo=NULL; /* Prevent CPR lockup */ */
                start=txa->pos;
                length=txa->length;
                /* Remove newline after line too. Except for last line,

--- a/Source/AWebAPL/tooltip.c
+++ b/Source/AWebAPL/tooltip.c
@@ -50,7 +50,7 @@ static struct MsgPort *ttport;
 
 /*-----------------------------------------------------------------------*/
 
-// Copy text to ttbuf, wordwrapping as necessary.
+/* Copy text to ttbuf, wordwrapping as necessary. */
 static void Wordwrap(UBYTE *text)
 {  UBYTE *p;
    long line,lastsp;
@@ -80,7 +80,7 @@ static void Wordwrap(UBYTE *text)
    Addtobuffer(&ttbuf,"",1);
 }
 
-// Close tooltip window
+/* Close tooltip window */
 static void Closetooltip(void)
 {  if(ttwinobject)
    {  DisposeObject(ttwinobject);
@@ -95,13 +95,13 @@ static void Closetooltip(void)
    tttick=FALSE;
 }
 
-// Check the tooltip message queue
+/* Check the tooltip message queue */
 static void Processtooltip(void)
 {  ULONG result;
    while((result=RA_HandleInput(ttwinobject,NULL))!=WMHI_LASTMSG);
 }
 
-// Check if mouse is at same position for 0.5 seconds. If so, open tooltip.
+/* Check if mouse is at same position for 0.5 seconds. If so, open tooltip. */
 static void Ticktooltip(long x,long y)
 {  struct Screen *screen;
    struct DrawInfo *dri;
@@ -174,8 +174,8 @@ static void Ticktooltip(long x,long y)
    }
 }
 
-// Check if mouse is over tooltip window. If so, close tooltip and set ticking again.
-// But allow first time overlap when the tooltip window is opened.
+/* Check if mouse is over tooltip window. If so, close tooltip and set ticking again. */
+/* But allow first time overlap when the tooltip window is opened. */
 static void Checktooltip(long x,long y)
 {  if(ttwindow)
    {  if(x>=ttwindow->LeftEdge && x<ttwindow->LeftEdge+ttwindow->Width

--- a/Source/AWebAPL/xaweb.c
+++ b/Source/AWebAPL/xaweb.c
@@ -155,7 +155,7 @@ static void Docommand(struct Fetchdriver *fd,UBYTE *cmd,BOOL arexx)
    ObtainSemaphore(&prefssema);
    commands=prefs.commands || (fd->flags&FDVF_COMMANDS);
    ReleaseSemaphore(&prefssema);
-//if(!fd->referer) fd->referer="file://";
+/*if(!fd->referer) fd->referer="file://"; */
    if(fd->referer
    && (STRNIEQUAL(fd->referer,"file://",7) || STRNIEQUAL(fd->referer,"x-aweb:",7))
    && (commands || Cmdwarnok(cmd,arexx)))


### PR DESCRIPTION
- Replaces // comments in Source/AWebAPL/ *.h/*.c with C89-compatible /* ... */.
- No functional changes; comment-only change to improve compatibility with SAS/C / vbcc.
- verified no URL-string corruption (no http:/* patterns) and no bidi chars in AWebAPL sources.”
