### PR TITLE
C89: replace remaining // comments in headers

### DIFF
--- a/Source/AWebAPL/awebcfg.h
+++ b/Source/AWebAPL/awebcfg.h
@@ -149,7 +149,7 @@ extern STRPTR __asm GetString(register __a0 struct LocaleInfo *li,
 extern void *maincatalog;
 extern UBYTE *Getmainstr(ULONG msg);
 
-// Library base pointers are now provided by proto headers
+/* Library base pointers are now provided by proto headers */
 
 extern UBYTE config[];              /* configuration name */
 extern struct Screen *pubscreen;

--- a/Source/AWebAPL/ezlists.h
+++ b/Source/AWebAPL/ezlists.h
@@ -16,7 +16,7 @@
  *
  **********************************************************************/
 
-// easy lists
+/* easy lists */
 
 #ifndef EZLISTS_H
 #define EZLISTS_H


### PR DESCRIPTION
- C89 compatibility: replace C++ style // comments with /* ... */ in headers.
- Supersedes #21/#22 (closed: wrong branch).