### PR TITLE
gopher: flush before append to avoid fd->block overflow

### DIFF
--- a/Source/AWebAPL/gopher.c
+++ b/Source/AWebAPL/gopher.c
@@ -276,6 +276,16 @@ static void Builddir(struct Fetchdriver *fd,struct GResponse *resp,long read)
    UBYTE type;
    UBYTE *icon;
    long length=0;
+
+   /* Keep a safety margin so sprintf() never runs into the end of fd->block */
+   const long FLUSH_MARGIN = 1024;
+
+   /* Defensive caps for untrusted gopher fields (keeps sprintf bounded) */
+   const long MAX_HOST = 255;
+   const long MAX_PORT = 15;
+   const long MAX_SEL  = 1024;
+   const long MAX_DESC = 1024;
+
    if(!Addtobuffer(&resp->buf,fd->block,read)) return;
    if(!resp->headerdone)
    {  sprintf(fd->block,"<html><h1>%s</h1>",AWEBSTR(MSG_AWEB_GOPHERMENU));
@@ -346,56 +356,76 @@ static void Builddir(struct Fetchdriver *fd,struct GResponse *resp,long read)
             case 'h':
             case 'I':
             case 's':
-               {  length+=sprintf(fd->block+length,
-                     "<BR>%s <A HREF=\"gopher://%s:%s/%c%s\">%s</A>",
-                     icon,host,hport,type,selector,descr);
-                  if(length>INPUTBLOCKSIZE-1000)
+               {
+                  if(length > fd->blocksize - FLUSH_MARGIN)
                   {  Updatetaskattrs(
                         AOURL_Data,fd->block,
                         AOURL_Datalength,length,
                         TAG_END);
-                     length=0;
+                     length = 0;
+                     fd->block[0] = '\0';
                   }
+                  length += sprintf(fd->block + length,
+                     "<BR>%s <A HREF=\"gopher://%.*s:%.*s/%c%.*s\">%.*s</A>",
+                     icon,
+                     (int)MAX_HOST, host,
+                     (int)MAX_PORT, hport,
+                     type,
+                     (int)MAX_SEL, selector,
+                     (int)MAX_DESC, descr);
                   break;
                }
             /* telnet type */
             case '8':
-               {  length+=sprintf(fd->block+length,
-                     "<BR>%s <A HREF=\"telnet://%s:%s\">%s</A>",
-                     icon,host,hport,descr);
-                  if(length>INPUTBLOCKSIZE-1000)
+               {
+                  if(length > fd->blocksize - FLUSH_MARGIN)
                   {  Updatetaskattrs(
                         AOURL_Data,fd->block,
                         AOURL_Datalength,length,
                         TAG_END);
-                     length=0;
+                     length = 0;
+                     fd->block[0] = '\0';
                   }
+                  length += sprintf(fd->block + length,
+                    "<BR>%s <A HREF=\"telnet://%.*s:%.*s\">%.*s</A>",
+                    icon,
+                    (int)MAX_HOST, host,
+                    (int)MAX_PORT, hport,
+                    (int)MAX_DESC, descr);
                   break;
                }
             /* www link type */
             case 'w':
-               {  length+=sprintf(fd->block+length,
-                     "<BR>%s <A HREF=\"http://%s:%s%s\">%s</A>",
-                     icon,host,hport,selector,descr);
-                  if(length>INPUTBLOCKSIZE-1000)
+               {
+                  if(length > fd->blocksize - FLUSH_MARGIN)
                   {  Updatetaskattrs(
                         AOURL_Data,fd->block,
                         AOURL_Datalength,length,
                         TAG_END);
-                     length=0;
+                     length = 0;
+                     fd->block[0] = '\0';
                   }
+                  length += sprintf(fd->block + length,
+                    "<BR>%s <A HREF=\"http://%.*s:%.*s%.*s\">%.*s</A>",
+                    icon,
+                    (int)MAX_HOST, host,
+                    (int)MAX_PORT, hport,
+                    (int)MAX_SEL, selector,
+                    (int)MAX_DESC, descr);
                   break;
                }
             /* info link type */
             case 'i':
-               {  length+=sprintf(fd->block+length,"<BR>%s",descr);
-                  if(length>INPUTBLOCKSIZE-1000)
+               {
+                  if(length > fd->blocksize - FLUSH_MARGIN)
                   {  Updatetaskattrs(
                         AOURL_Data,fd->block,
                         AOURL_Datalength,length,
                         TAG_END);
-                     length=0;
+                     length = 0;
+                     fd->block[0] = '\0';
                   }
+                  length += sprintf(fd->block + length, "<BR>%.*s", (int)MAX_DESC, descr);
                   break;
                }
             default:
@@ -404,14 +434,15 @@ static void Builddir(struct Fetchdriver *fd,struct GResponse *resp,long read)
       }
       else
       {  /* show any information that doesn't have a known type */
-         length+=sprintf(fd->block+length,"<BR>%s",descr);
-         if(length>INPUTBLOCKSIZE-1000)
+         if(length > fd->blocksize - FLUSH_MARGIN)
          {  Updatetaskattrs(
                AOURL_Data,fd->block,
                AOURL_Datalength,length,
                TAG_END);
-            length=0;
+             length = 0;
+             fd->block[0] = '\0';
          }
+         length += sprintf(fd->block + length, "<BR>%.*s", (int)MAX_DESC, descr);
       }
       p++;
       Deleteinbuffer(&resp->buf,0,p-resp->buf.buffer);

--- a/Source/AWebAPL/gopher.c
+++ b/Source/AWebAPL/gopher.c
@@ -285,14 +285,14 @@ static void Builddir(struct Fetchdriver *fd,struct GResponse *resp,long read)
    UBYTE *icon;
    long length=0;
 
-   /* Keep a safety margin so sprintf() never runs into the end of fd->block */
-   const long FLUSH_MARGIN = 1024;
-
    /* Defensive caps for untrusted gopher fields (keeps sprintf bounded) */
+   const long FLUSH_MARGIN = 1024;
    const long MAX_HOST = 255;
    const long MAX_PORT = 15;
-   const long MAX_SEL  = 1024;
-   const long MAX_DESC = 1024;
+
+   /* Keep these small enough that one sprintf() chunk always fits in FLUSH_MARGIN */
+   const long MAX_SEL  = 255;
+   const long MAX_DESC = 255;
 
    if(!Addtobuffer(&resp->buf,fd->block,read)) return;
    if(!resp->headerdone)

--- a/Source/AWebAPL/gopher.c
+++ b/Source/AWebAPL/gopher.c
@@ -478,12 +478,13 @@ static void Deleteperiods(struct Fetchdriver *fd,struct GResponse *resp,long rea
       p++;
       memmove(fd->block+length,begin,p-begin);
       length+=p-begin;
-      if(length>INPUTBLOCKSIZE-1000)
+      if(length > fd->blocksize - 1024)
       {  Updatetaskattrs(
             AOURL_Data,fd->block,
             AOURL_Datalength,length,
             TAG_END);
          length=0;
+         fd->block[0] = '\0';
       }
       Deleteinbuffer(&resp->buf,0,p-resp->buf.buffer);
    }

--- a/Source/AWebAPL/gopher.c
+++ b/Source/AWebAPL/gopher.c
@@ -29,6 +29,26 @@
 #include "task.h"
 #include "awebtcp.h"
 #include <exec/resident.h>
+#include <proto/utility.h>
+#include <stdarg.h>
+
+static long SNPrintf(UBYTE *buf, long size, const UBYTE *fmt, ...)
+{
+   va_list ap;
+   long len;
+
+   if(!buf || size <= 0) return 0;
+
+   va_start(ap, fmt);
+   len = VSNPrintf((STRPTR)buf, size, (STRPTR)fmt, ap);
+   va_end(ap);
+
+   if(len < 0) len = 0;
+   if(len >= size) len = size - 1;
+   buf[len] = '\0';
+
+   return len;
+}
 
 #ifndef LOCALONLY
 
@@ -241,7 +261,7 @@ static BOOL Makegopheraddr(struct Gopheraddr *ha,UBYTE *name)
          long remain = (long)(ha->buf + len + 2 - q);
          if(remain > 0)
          {
-            strncpy(q, p, remain - 1);
+            Strncpy(q, p, remain - 1);
             q[remain - 1] = '\0';
          }
       }
@@ -285,20 +305,19 @@ static void Builddir(struct Fetchdriver *fd,struct GResponse *resp,long read)
    UBYTE *icon;
    long length=0;
 
-   /* Defensive caps for untrusted gopher fields (keeps sprintf bounded) */
+   /* Defensive caps for untrusted gopher fields (keeps formatted output bounded) */
    const long FLUSH_MARGIN = 1024;
    const long MAX_HOST = 255;
    const long MAX_PORT = 15;
 
-   /* Keep these small enough that one sprintf() chunk always fits in FLUSH_MARGIN */
+   /* Keep these small enough that one formatted chunk always fits in FLUSH_MARGIN */
    const long MAX_SEL  = 255;
    const long MAX_DESC = 255;
 
    if(!Addtobuffer(&resp->buf,fd->block,read)) return;
    if(!resp->headerdone)
-   {  length = sprintf(fd->block, "<html><h1>%s</h1>", AWEBSTR(MSG_AWEB_GOPHERMENU));
-      if(length < 0) length = 0;
-      if(length >= fd->blocksize) length = fd->blocksize - 1;
+   {  length = SNPrintf(fd->block, fd->blocksize,
+         "<html><h1>%s</h1>", AWEBSTR(MSG_AWEB_GOPHERMENU));
       resp->headerdone=TRUE;
    }
    for(;;)
@@ -374,7 +393,7 @@ static void Builddir(struct Fetchdriver *fd,struct GResponse *resp,long read)
                      length = 0;
                      fd->block[0] = '\0';
                   }
-                  length += sprintf(fd->block + length,
+                  length += SNPrintf(fd->block + length, fd->blocksize - length,
                      "<BR>%s <A HREF=\"gopher://%.*s:%.*s/%c%.*s\">%.*s</A>",
                      icon,
                      (int)MAX_HOST, host,
@@ -395,7 +414,7 @@ static void Builddir(struct Fetchdriver *fd,struct GResponse *resp,long read)
                      length = 0;
                      fd->block[0] = '\0';
                   }
-                  length += sprintf(fd->block + length,
+                  length += SNPrintf(fd->block + length, fd->blocksize - length,
                     "<BR>%s <A HREF=\"telnet://%.*s:%.*s\">%.*s</A>",
                     icon,
                     (int)MAX_HOST, host,
@@ -414,7 +433,7 @@ static void Builddir(struct Fetchdriver *fd,struct GResponse *resp,long read)
                      length = 0;
                      fd->block[0] = '\0';
                   }
-                  length += sprintf(fd->block + length,
+                  length += SNPrintf(fd->block + length, fd->blocksize - length,
                     "<BR>%s <A HREF=\"http://%.*s:%.*s%.*s\">%.*s</A>",
                     icon,
                     (int)MAX_HOST, host,
@@ -434,7 +453,7 @@ static void Builddir(struct Fetchdriver *fd,struct GResponse *resp,long read)
                      length = 0;
                      fd->block[0] = '\0';
                   }
-                  length += sprintf(fd->block + length, "<BR>%.*s", (int)MAX_DESC, descr);
+                  length += SNPrintf(fd->block + length, fd->blocksize - length, "<BR>%.*s", (int)MAX_DESC, descr);
                   break;
                }
             default:
@@ -451,7 +470,7 @@ static void Builddir(struct Fetchdriver *fd,struct GResponse *resp,long read)
              length = 0;
              fd->block[0] = '\0';
          }
-         length += sprintf(fd->block + length, "<BR>%.*s", (int)MAX_DESC, descr);
+         length += SNPrintf(fd->block + length, fd->blocksize - length, "<BR>%.*s", (int)MAX_DESC, descr);
       }
       p++;
       Deleteinbuffer(&resp->buf,0,p-resp->buf.buffer);
@@ -499,9 +518,8 @@ static void Deleteperiods(struct Fetchdriver *fd,struct GResponse *resp,long rea
 static void Makeindex(struct Fetchdriver *fd)
 {  long length;
    /* we ought to do different msg for cso and normal indexes */
-   length = sprintf(fd->block, "<html><h1>%s</h1><isindex>", AWEBSTR(MSG_AWEB_GOPHERINDEX));
-   if(length < 0) length = 0;
-   if(length >= fd->blocksize) length = fd->blocksize - 1;
+   length = SNPrintf(fd->block, fd->blocksize,
+      "<html><h1>%s</h1><isindex>", AWEBSTR(MSG_AWEB_GOPHERINDEX));
    Updatetaskattrs(
       AOURL_Data,fd->block,
       AOURL_Datalength,length,
@@ -534,9 +552,8 @@ __saveds __asm void Fetchdrivertask(register __a0 struct Fetchdriver *fd)
                   {  Updatetaskattrs(AOURL_Netstatus,NWS_CONNECT,TAG_END);
                      Tcpmessage(fd,TCPMSG_CONNECT,"Gopher",hent->h_name);
                      if(!a_connect(sock,hent,ha.port,SocketBase))
-                     {  length = sprintf(fd->block, "%s\r\n", ha.selector ? ha.selector : "");
-                        if(length < 0) length = 0;
-                        if(length >= fd->blocksize) length = fd->blocksize - 1;
+                     {  length = SNPrintf(fd->block, fd->blocksize,
+                           "%s\r\n", ha.selector ? ha.selector : "");
                         result=(a_send(sock,fd->block,length,0,SocketBase)==length);
                         if(result)
                         {  Updatetaskattrs(AOURL_Netstatus,NWS_WAIT,TAG_END);

--- a/Source/AWebAPL/gopher.c
+++ b/Source/AWebAPL/gopher.c
@@ -236,7 +236,15 @@ static BOOL Makegopheraddr(struct Gopheraddr *ha,UBYTE *name)
    if(*p) p++; /* skip / */
    if(*p)
    {  ha->type=*p++;
-      strcpy(q,p);
+      /* bounded copy: avoid overflowing ha->buf */
+      {
+         long remain = (long)(ha->buf + len + 2 - q);
+         if(remain > 0)
+         {
+            strncpy(q, p, remain - 1);
+            q[remain - 1] = '\0';
+         }
+      }
    }
    else
    {  ha->type='1';
@@ -288,8 +296,9 @@ static void Builddir(struct Fetchdriver *fd,struct GResponse *resp,long read)
 
    if(!Addtobuffer(&resp->buf,fd->block,read)) return;
    if(!resp->headerdone)
-   {  sprintf(fd->block,"<html><h1>%s</h1>",AWEBSTR(MSG_AWEB_GOPHERMENU));
-      length=strlen(fd->block);
+   {  length = sprintf(fd->block, "<html><h1>%s</h1>", AWEBSTR(MSG_AWEB_GOPHERMENU));
+      if(length < 0) length = 0;
+      if(length >= fd->blocksize) length = fd->blocksize - 1;
       resp->headerdone=TRUE;
    }
    for(;;)
@@ -489,8 +498,9 @@ static void Deleteperiods(struct Fetchdriver *fd,struct GResponse *resp,long rea
 static void Makeindex(struct Fetchdriver *fd)
 {  long length;
    /* we ought to do different msg for cso and normal indexes */
-   sprintf(fd->block,"<html><h1>%s</h1><isindex>",AWEBSTR(MSG_AWEB_GOPHERINDEX));
-   length=strlen(fd->block);
+   length = sprintf(fd->block, "<html><h1>%s</h1><isindex>", AWEBSTR(MSG_AWEB_GOPHERINDEX));
+   if(length < 0) length = 0;
+   if(length >= fd->blocksize) length = fd->blocksize - 1;
    Updatetaskattrs(
       AOURL_Data,fd->block,
       AOURL_Datalength,length,
@@ -523,7 +533,9 @@ __saveds __asm void Fetchdrivertask(register __a0 struct Fetchdriver *fd)
                   {  Updatetaskattrs(AOURL_Netstatus,NWS_CONNECT,TAG_END);
                      Tcpmessage(fd,TCPMSG_CONNECT,"Gopher",hent->h_name);
                      if(!a_connect(sock,hent,ha.port,SocketBase))
-                     {  length=sprintf(fd->block,"%s\r\n",ha.selector);
+                     {  length = sprintf(fd->block, "%s\r\n", ha.selector ? ha.selector : "");
+                        if(length < 0) length = 0;
+                        if(length >= fd->blocksize) length = fd->blocksize - 1;
                         result=(a_send(sock,fd->block,length,0,SocketBase)==length);
                         if(result)
                         {  Updatetaskattrs(AOURL_Netstatus,NWS_WAIT,TAG_END);


### PR DESCRIPTION
This PR hardens gopher directory rendering against fd->block overflows.
It flushes the output buffer before appending new formatted content and adds defensive caps for untrusted gopher fields so sprintf() stays bounded.
Also aligns the flush logic in Deleteperiods() to avoid writing past the buffer on long lines.
Scope is limited to Source/AWebAPL/gopher.c and keeps behavior unchanged aside from preventing potential memory corruption.