### PR TITLE
CONTRIBUTING: document native API first policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,15 @@ Sign off commits with:
 
 ```bash
 git commit -s -m "your commit message"
+```
+
+## Native API first
+
+For bug fixes, refactoring and hardening changes, prefer native AmigaOS APIs and libraries over libc functions whenever suitable system APIs already exist.
+
+Examples include:
+- `utility.library` for string and buffer handling where applicable
+- DOS/Exec APIs for filesystem, process and system services
+- Intuition/ReAction APIs for UI-related work
+
+If no suitable native API exists, libc may still be used, but native OS functionality should be considered first.


### PR DESCRIPTION
Document the preferred contribution style for hardening/refactoring work:
prefer native AmigaOS/NDK APIs over libc functions where suitable system APIs already exist.

Also closes an unclosed markdown code block in CONTRIBUTING.md.