### PR TITLE
core: use utility.library compare macros in shared headers

### DIFF
--- a/Source/AWebAPL/awebcfg.h
+++ b/Source/AWebAPL/awebcfg.h
@@ -114,10 +114,10 @@
 #endif
 
 #ifndef STREQUAL
-#define STRNIEQUAL(a,b,n)  !strnicmp(a,b,n)
-#define STRNEQUAL(a,b,n)   !strncmp(a,b,n)
-#define STRIEQUAL(a,b)     !stricmp(a,b)
-#define STREQUAL(a,b)      !strcmp(a,b)
+#define STRNIEQUAL(a,b,n)  (Strnicmp((a),(b),(n)) == SAME)
+#define STRNEQUAL(a,b,n)   (strncmp((a),(b),(n)) == 0)
+#define STRIEQUAL(a,b)     (Stricmp((a),(b)) == SAME)
+#define STREQUAL(a,b)      (strcmp((a),(b)) == 0)
 #endif
 
 #ifndef BOOLVAL

--- a/Source/AWebAPL/awebdef.h
+++ b/Source/AWebAPL/awebdef.h
@@ -134,10 +134,10 @@ extern BOOL has35;
 #define ALLOCSTRUCT(s,n,f)    ALLOCTYPE(struct s,n,f)
 #define FREE(p)            Freemem(p)
 
-#define STRNIEQUAL(a,b,n)  !strnicmp(a,b,n)
-#define STRNEQUAL(a,b,n)   !strncmp(a,b,n)
-#define STRIEQUAL(a,b)     !stricmp(a,b)
-#define STREQUAL(a,b)      !strcmp(a,b)
+#define STRNIEQUAL(a,b,n)  (Strnicmp((a),(b),(n)) == SAME)
+#define STRNEQUAL(a,b,n)   (strncmp((a),(b),(n)) == 0)
+#define STRIEQUAL(a,b)     (Stricmp((a),(b)) == SAME)
+#define STREQUAL(a,b)      (strcmp((a),(b)) == 0)
 
 #define BOOLVAL(x)         (BOOL)((x)!=0)
 


### PR DESCRIPTION
Use utility.library for the shared case-insensitive compare macros in awebcfg.h and awebdef.h.

This changes:
- STRIEQUAL -> Stricmp(...) == SAME
- STRNIEQUAL -> Strnicmp(...) == SAME

Case-sensitive macros remain standard C:
- STREQUAL -> strcmp(...) == 0
- STRNEQUAL -> strncmp(...) == 0

Scope is intentionally limited to the shared header macros only.